### PR TITLE
feat: add safe stdio credentials and OAuth DCR secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## [Unreleased]
 
+### Added
+
+- 市场 stdio 连接器支持声明多个凭据输入字段，并将用户在本机填写的值安全绑定到指定环境变量；目录仍禁止携带真实凭据，Registry 探针仍不执行本地命令。
+- OAuth 动态客户端注册支持 `client_secret_post` 与 `client_secret_basic`，客户端密钥随本机 Grant 用于授权码交换、刷新和撤销。
+
+### Security
+
+- stdio 凭据值不进入 catalog/status/log；字段映射会校验环境变量名、未知引用、重复声明和未使用的必填字段。
+- OAuth DCR 客户端密钥不进入公开输出，并支持服务端提供的到期时间检查。
+
 ## [0.2.17] - 2026-08-24
 
 ### Documentation

--- a/README.en.md
+++ b/README.en.md
@@ -18,12 +18,12 @@ Browse and install MCP connectors from different providers in DeepSeek Harness D
 
 - A primary sidebar entry below New Conversation and above workspaces/conversations, with a public footer-slot fallback for incompatible DSH DOM versions.
 - Searchable Marketplace and Installed views; the default Marketplace groups cards into Featured plus nine business-category sections, previews four cards per section, keeps the category bar visible while scrolling, and shows every card when a single category is selected.
-- OAuth 2.0 Authorization Code with PKCE, API key/Bearer/unauthenticated HTTP configuration, stdio local-process configuration, and `mcpServers` JSON import.
+- OAuth 2.0 Authorization Code with PKCE, including DCR public clients and `client_secret_post` / `client_secret_basic`; API key/Bearer/unauthenticated HTTP configuration, stdio local-process configuration, and `mcpServers` JSON import.
 - Installation from a credential-free connector descriptor URL.
-- Credential and MCP initialize validation before API-key connectors are saved as installed.
+- Credential and MCP initialize validation before HTTP API-key connectors are saved as installed, plus declarative multi-field credential-to-env bindings for marketplace stdio connectors.
 - Dynamic tool discovery grouped by MCP server, including descriptions, search, batched rendering, and an independent scroll region.
 - Curated prompt templates that can open a DSH conversation and prefill its draft; missing variables are requested before the prompt is sent.
-- Persistent connection lifecycle management: restore on restart, enable/disable, disconnect, refresh OAuth tokens, and revoke authorization.
+- Persistent connection lifecycle management: restore on restart, enable/disable, disconnect, refresh OAuth tokens, and revoke authorization. DCR client secrets are kept with the local grant only.
 - Built-in, remote, and local catalogs with `published` and `featured` controls.
 - A standalone remote Registry, allowing new marketplace cards to appear after refresh without publishing a new npm version.
 - Explicit, non-destructive migration of authorization from the two earlier Qichacha OAuth plugins.
@@ -116,7 +116,8 @@ See [CHANGELOG.md](CHANGELOG.md) for version history and [docs/DESKTOP-E2E.md](d
 - External URLs must use HTTPS; HTTP is allowed only for loopback development.
 - Remote descriptors and catalogs are limited to 2 MiB, Web API requests to 1 MiB, and imported JSON is scanned for credential fields before normalization.
 - Streamable HTTP and stdio are supported end to end. Legacy `sse` entries are normalized to Streamable HTTP. The connector passes stdio `command/args/env/cwd` to `@deepseek-ai/dsh-mcp-client` instead of reimplementing process transport.
-- stdio starts a local process. Import or connect only trusted commands and packages; catalog descriptors may not contain token/secret-shaped environment variables.
+- stdio starts a local process. Import or connect only trusted commands and packages. Catalog descriptors may declare `credentialFields` and `credentialBindings`, but may never contain actual token/secret values; user input is injected only into the local Host process environment.
+- OAuth DCR client secrets share the same local-only boundary as access and refresh tokens and are omitted from catalog/status responses and logs.
 - The primary sidebar placement uses the stable DSH `data-slot` marker and falls back to the footer if that marker is removed.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
 - 图形化添加：手动 HTTP/stdio、`mcpServers` JSON、连接器描述 URL 三种入口，失败时保留表单并给出修复建议。
 - 连接器详情：精选 Prompt 优先展示，点击可带入 DSH 新会话；工具按 Server 分组，支持描述、搜索和独立滚动。
 - Prompt 模板：使用 `{{company}}` 等变量，发送前填写真实查询主体。
-- 三种接入：OAuth 2.0 PKCE、自定义 HTTP/stdio、导入 `mcpServers` JSON；也支持从连接器描述 URL 安装。
-- 市场 Bearer/API Key 连接器先执行 MCP initialize 连通性与凭据校验，全部 Server 通过后才持久化凭据并进入“已安装”。
-- 生命周期管理：连接持久化、重启恢复、启停、断开、OAuth 刷新与撤销。
+- 三种接入：OAuth 2.0 PKCE、自定义 HTTP/stdio、导入 `mcpServers` JSON；也支持从连接器描述 URL 安装。OAuth 动态注册兼容公共客户端以及 `client_secret_post` / `client_secret_basic` 机密客户端。
+- 市场 Bearer/API Key 连接器先执行 MCP initialize 连通性与凭据校验，全部 HTTP Server 通过后才持久化凭据并进入“已安装”；stdio 卡片可声明多个本机凭据字段及其环境变量映射。
+- 生命周期管理：连接持久化、重启恢复、启停、断开、OAuth 刷新与撤销；DCR 返回的客户端密钥与 Token 一同只保存在本机。
 - 目录运营：内置目录、远程 registry、本地覆盖，支持 `published` 上下架与 `featured` 精选。
 - 独立远程 Registry：新市场卡片合并后客户端刷新即可见，无需重新发布 npm；远程不可用时自动回退内置目录。
 - Registry 工具链：Schema/唯一性/密钥审计、MCP/OAuth 无凭据探针、每周健康巡检。
@@ -115,7 +115,8 @@ stdio 传输的架构、透传边界与安全约束见 [docs/STDIO-SUPPORT.md](d
 - 外部 URL 仅允许 HTTPS，HTTP 仅允许回环地址；导入配置会校验 URL 与 Header。
 - 远程目录/描述响应限制 2 MiB，Web API 请求限制 1 MiB；原始 JSON 在归一化前扫描凭据字段。
 - 完整覆盖 Streamable HTTP 与 stdio；旧 `sse` 配置在导入/恢复时归一为 Streamable HTTP。stdio 的 `command/args/env/cwd` 原样交给 `@deepseek-ai/dsh-mcp-client`，插件本身不重复实现进程传输。
-- stdio 会启动本机进程：仅导入或连接可信命令/软件包。市场目录不得携带 token/secret 类环境变量；用户凭据只允许在本机配置。
+- stdio 会启动本机进程：仅导入或连接可信命令/软件包。市场目录只能用 `credentialFields` + `credentialBindings` 声明输入与 env 映射，不得携带真实 token/secret；用户填写值只写入本机连接记录并交给 Host。
+- OAuth DCR 的 `client_secret` 与 Access/Refresh Token 采用相同的本机存储边界，不会进入市场 API、状态输出或日志。
 - 顶部入口通过 DSH 稳定 `data-slot` 定位并使用 React Portal；DSH 若移除该标记，入口会回退到底部，不影响连接器功能。
 - 旧授权迁移必须显式确认，只复制不删除；确认新连接可用后再手动停用旧插件。
 

--- a/docs/MARKET-REGISTRATION.md
+++ b/docs/MARKET-REGISTRATION.md
@@ -16,7 +16,7 @@
 3. 在插件中选择「添加连接 → 市场卡片」，粘贴 URL。
 4. Schema/密钥审计通过后，卡片会持久化到本机市场。
 
-Bearer/API Key 型连接器可在卡片上点「配置」，一次填写凭据后批量连接该卡片的所有 Server。
+Bearer/API Key 型连接器可在卡片上点「配置」，一次填写凭据后批量连接该卡片的所有 Server。stdio 卡片可通过 `auth.credentialFields` 声明多个输入，并用 `servers[].credentialBindings` 映射到本地进程环境变量；描述文件仍不得包含真实值。
 
 ## 3. 提交公共市场
 
@@ -47,7 +47,10 @@ Bearer/API Key 型连接器可在卡片上点「配置」，一次填写凭据�
 - Authorization Server Metadata（RFC 8414）；
 - `authorization_endpoint`、`token_endpoint`、`registration_endpoint`；`revocation_endpoint` 建议提供，但按标准属于可选能力；
 - Dynamic Client Registration，且支持 loopback callback URI；
+- DCR 的 `token_endpoint_auth_method` 可为 `none`、`client_secret_post` 或 `client_secret_basic`；后两者的注册响应必须返回 `client_secret`；
 - Refresh Token；如提供撤销端点，插件会在断开/清理授权时撤销 Refresh Token，否则只删除 DSH 本机授权记录。
+
+DCR 返回的 `client_secret` 由插件与 Access/Refresh Token 一同保存在 DSH 本机 Grant 中，只用于 Token 交换、刷新和撤销，不会出现在目录、状态输出或日志。描述文件只填写服务端支持的 `tokenEndpointAuthMethod`，不得预置客户端密钥。
 
 插件优先读取 RFC 8414 Authorization Server Metadata；若动态注册或撤销端点缺失，会再读取 OIDC Discovery 并仅补齐缺失字段。OAuth 元数据中的授权、Token 等标准端点始终优先。
 
@@ -59,7 +62,7 @@ Bearer/API Key 型连接器可在卡片上点「配置」，一次填写凭据�
   "id": "vendor-legal",
   "name": "厂商·法律数据",
   "vendor": "厂商名称",
-  "category": "法律数据",
+  "category": "法律合规",
   "summary": "法规与案例检索",
   "published": true,
   "auth": {
@@ -79,6 +82,36 @@ Bearer/API Key 型连接器可在卡片上点「配置」，一次填写凭据�
   ]
 }
 ```
+
+### 5.1 需要本机环境变量的 stdio 卡片
+
+目录只声明字段和映射，示例见 `registry/connectors/stdio-credential.sample.json`：
+
+```json
+{
+  "auth": {
+    "mode": "api-key",
+    "credentialFields": [
+      { "key": "apiToken", "label": "API Token", "required": true, "secret": true },
+      { "key": "region", "label": "区域", "required": true, "secret": false }
+    ]
+  },
+  "servers": [{
+    "serverKey": "main",
+    "serverName": "vendor-local-service",
+    "transport": "stdio",
+    "command": "npx",
+    "args": ["-y", "@vendor/example-mcp-server"],
+    "env": { "LOG_LEVEL": "info" },
+    "credentialBindings": {
+      "VENDOR_API_TOKEN": "apiToken",
+      "VENDOR_REGION": "region"
+    }
+  }]
+}
+```
+
+`credentialBindings` 的 key 必须是合法环境变量名，value 必须引用已声明的字段。不要在 `env`、`credentialFields` 或其他目录字段中填写 Token、Secret、API Key、密码或 Cookie。
 
 ## 6. 北大法宝当前适配结论
 

--- a/docs/STDIO-SUPPORT.md
+++ b/docs/STDIO-SUPPORT.md
@@ -146,12 +146,13 @@ const Config = z.union([
 
 采用「宽松 schema + normalize 阶段显式校验」风格（与现有代码注释「宽松校验、显式报错」一致）。
 
-### 决策 3：stdio 鉴权通过 `env`，不抽象 `auth.mode`
+### 决策 3：stdio 凭据使用声明式字段绑定，真实值仅在本机注入 `env`
 
-- stdio 是本地进程，密钥通过环境变量传递（如 `GITHUB_TOKEN`、`OPENAI_API_KEY`）
-- 每个 server 的密钥 env 变量名不同，无法统一抽象成 `auth.mode` 的 header 机制
-- 设计：目录里 stdio 连接器的 `env` 只含非敏感默认值；用户 configure 时填含密钥的 env
-- stdio 型连接器的 `auth.mode` 保持 `none`（或 undefined）
+- stdio 是本地进程，密钥最终仍通过环境变量传递（如 `GITHUB_TOKEN`、`OPENAI_API_KEY`）。
+- 无凭据的 stdio 连接器使用 `auth.mode: "none"`；需要用户输入的卡片使用 `bearer` 或 `api-key`，并在 `auth.credentialFields` 声明一个或多个输入字段。
+- `servers[].credentialBindings` 只保存“环境变量名 → 凭据字段 key”的映射；`servers[].env` 只能包含非敏感默认值。
+- 用户输入存入本机 `ConnectionRecord.env` 并透传给 `dsh-mcp-client`，不回写目录，也不出现在 catalog/status/log 输出。
+- Registry 探针只校验声明与命令形状，绝不执行本地 stdio 命令。
 
 ### 决策 4：mcp-provision 按 transport 分支透传
 
@@ -611,9 +612,8 @@ cwd: { type: 'string', description: 'transport=stdio 时的工作目录，默认
 | stdio `command` 可执行任意本地命令 | command 来自（a）维护者审核的 catalog，或（b）用户主动 configure，风险可控；DSH 运行时沙箱机制兜底 |
 | `env` 里的密钥泄露到日志 | dsh-mcp-client 的 `buildChildEnv` 已用 `scrubbedParentEnv()` 清理敏感父环境变量；我们持久化 env 到 storage domain 与现有 headers 鉴权一致，无新增泄露面 |
 | `cwd` 空字符串导致 spawn 异常 | provisioning 层显式 `record.cwd \|\| process.cwd()` |
-| 目录夹带密钥 | 复用现有 `auditRawDescriptor` 的密钥字段审计，对 `env` 里的 `token/secret/key/password` 字段同样拦截（需在 §5.9 补测试） |
-
-> ⚠️ **需补充**：`catalog.js` 的 `auditDescriptor` / `auditRawDescriptor` 目前审计 `servers[].headers` 的密钥类字段，需确认 `servers[].env` 也被审计（避免目录里 stdio 的 env 夹带 token）。
+| 目录夹带密钥 | `auditRawDescriptor` 拒绝真实凭据字段，`auditDescriptor` 拒绝 `env` 中的 token/secret/API Key/password 类变量；只允许 `credentialBindings` 引用已声明字段 |
+| 凭据映射错误或未使用 | Schema 与目录审计检查字段 key、env 名、重复映射、未知引用及未被任何 HTTP/stdio Server 使用的必填字段 |
 
 ---
 
@@ -649,6 +649,8 @@ cwd: { type: 'string', description: 'transport=stdio 时的工作目录，默认
    - `npm run check`（lint + test + verify-pack）全绿
 4. **安全**：
    - 目录里 stdio 连接器的 `env` 含 token/secret 字段时被 `auditRawDescriptor` 拦截
+   - 多字段 `credentialFields` / `credentialBindings` 通过校验，未知引用与缺失必填值被拒绝
+   - 真实值只进入本机连接记录与 Host env，catalog/status/log 均不返回
 
 ---
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -69,7 +69,9 @@ dsh web
 
 Bearer/API Key 连接器会先执行 MCP `initialize` 验证。所有 Server 通过后，凭据才会保存并出现在“已安装”中；验证失败不会写入新凭据。
 
-OAuth 一键连接要求服务商支持标准 OAuth 2.1/PKCE 和公开元数据发现。插件不会要求用户把 OAuth Token 复制到聊天中。
+stdio 市场卡片也可能显示一个或多个凭据字段，例如 API Token、区域或租户标识。卡片目录只声明字段名称及其环境变量映射；提交后，真实值仅保存到 DSH 本机连接记录，并由插件注入该 stdio 进程的 `env`。市场、状态页和日志不会返回这些值。stdio 由 Host 托管，配置成功表示命令已注册；最终工具可用性仍以本机进程启动结果为准。
+
+OAuth 一键连接要求服务商支持标准 OAuth 2.1/PKCE 和公开元数据发现。动态客户端注册既支持无需客户端密钥的 `none`，也支持服务商签发密钥的 `client_secret_post` 与 `client_secret_basic`。客户端密钥仅与 OAuth Grant 一同保存在 DSH 本机，用于换取、刷新和撤销 Token；插件不会要求用户把 OAuth Token 或客户端密钥复制到聊天中。
 
 ## 5. 查看详情、Prompt 与工具
 
@@ -140,6 +142,8 @@ OAuth 断开时，插件会尽力调用服务商的撤销端点；无撤销端�
 ## 8. 安全边界
 
 - 凭据仅保存在 DSH storage domain，不进入市场目录、Git 仓库或对话历史。
+- stdio 目录只能声明凭据字段与 env 映射，不能给出真实值；Registry 探针不会执行目录中的本地命令。
+- OAuth 动态注册返回的 `client_secret` 不出现在目录、连接状态或日志中；断开连接时与 Refresh Token 一起尽力撤销并删除本机记录。
 - 外部 HTTP 地址必须使用 HTTPS；仅本机回环开发地址允许 HTTP。
 - Registry 健康探针不持有用户凭据，也绝不会执行目录里的 stdio 命令。
 - 连接器能看到的数据和能执行的操作取决于你授予的账户权限；优先使用最小权限 Token/API Key。

--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -16,6 +16,11 @@ export function auditRawDescriptor(raw, path = 'connector') {
   if (!raw || typeof raw !== 'object') return raw;
   for (const [key, value] of Object.entries(raw)) {
     const fieldPath = `${path}.${key}`;
+    // credentialBindings 的 key 是待注入的环境变量名，value 只能是凭据字段引用；
+    // 真实值会在本机表单提交后写入 ConnectionRecord，不允许出现在目录中。
+    if (key === 'credentialBindings') continue;
+    // credentialFields[].secret 只是“以密码框显示”的布尔声明，不是密钥值。
+    if (key === 'secret' && typeof value === 'boolean' && /\.auth\.credentialFields\.\d+\.secret$/.test(fieldPath)) continue;
     if (SECRET_KEY_RE.test(key) && value !== undefined && value !== null && String(value).trim() !== '') {
       throw new Error(`${fieldPath} 禁止携带凭证或密钥`);
     }
@@ -38,15 +43,41 @@ export function loadBundledCatalog() {
 
 /** 安全审计：目录禁止携带密钥、URL 协议白名单、header 名白名单。 */
 export function auditDescriptor(descriptor) {
+  const credentialFields = descriptor.auth.credentialFields ?? [];
+  const credentialKeys = new Set();
+  for (const field of credentialFields) {
+    if (credentialKeys.has(field.key)) throw new Error(`connector "${descriptor.id}" auth.credentialFields key 重复: ${field.key}`);
+    credentialKeys.add(field.key);
+  }
+  const referencedCredentials = new Set();
   for (const server of descriptor.servers) {
     if (server.transport === 'stdio') {
-      if (descriptor.auth.mode !== 'none') {
-        throw new Error(`connector "${descriptor.id}" 的 stdio server 只能使用 auth.mode=none；凭据应由用户本机 env 配置`);
-      }
       for (const name of Object.keys(server.env ?? {})) {
         if (SECRET_ENV_RE.test(name)) {
           throw new Error(`connector "${descriptor.id}" servers[].env 禁止携带密钥类变量: ${name}`);
         }
+      }
+      const bindings = server.credentialBindings ?? {};
+      if (descriptor.auth.mode === 'oauth2-pkce') {
+        throw new Error(`connector "${descriptor.id}" 的 stdio server 不支持 auth.mode=oauth2-pkce`);
+      }
+      if (descriptor.auth.mode === 'none' && Object.keys(bindings).length > 0) {
+        throw new Error(`connector "${descriptor.id}" 的 stdio credentialBindings 需要 bearer/api-key 凭据定义`);
+      }
+      if (['bearer', 'api-key'].includes(descriptor.auth.mode) && Object.keys(bindings).length === 0) {
+        throw new Error(`connector "${descriptor.id}" 的凭据型 stdio server 必须声明 credentialBindings`);
+      }
+      for (const [envName, credentialKey] of Object.entries(bindings)) {
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(envName)) {
+          throw new Error(`connector "${descriptor.id}" credentialBindings 环境变量名非法: ${envName}`);
+        }
+        if (Object.hasOwn(server.env ?? {}, envName)) {
+          throw new Error(`connector "${descriptor.id}" credentialBindings 与 servers[].env 重复声明: ${envName}`);
+        }
+        if (!credentialKeys.has(credentialKey)) {
+          throw new Error(`connector "${descriptor.id}" credentialBindings 引用了未知凭据字段: ${credentialKey}`);
+        }
+        referencedCredentials.add(credentialKey);
       }
       continue;
     }
@@ -55,6 +86,15 @@ export function auditDescriptor(descriptor) {
       assertSafeHeaderName(name);
       if (/authorization|token|secret|api[-_]?key/i.test(name)) {
         throw new Error(`connector "${descriptor.id}" servers[].headers 禁止携带密钥类头: ${name}`);
+      }
+    }
+  }
+  if (['bearer', 'api-key'].includes(descriptor.auth.mode)) {
+    const httpServers = descriptor.servers.filter((server) => server.transport === 'streamable-http');
+    if (httpServers.length > 0 && credentialFields[0]) referencedCredentials.add(credentialFields[0].key);
+    for (const field of credentialFields) {
+      if (field.required && !referencedCredentials.has(field.key)) {
+        throw new Error(`connector "${descriptor.id}" 必填凭据字段未被 HTTP 或 stdio 使用: ${field.key}`);
       }
     }
   }

--- a/lib/connectors/oauth-connector.js
+++ b/lib/connectors/oauth-connector.js
@@ -31,11 +31,17 @@ export async function oauthAuthorize({ connector, config, logger, signal }) {
   if (!issuer) throw new Error(`connector "${connector.id}" missing issuer`);
 
   const metadata = await discoverServerMetadata(issuer, config.requestTimeoutMs);
+  const requestedAuthMethod = connector.auth.tokenEndpointAuthMethod ?? 'none';
+  if (metadata.tokenEndpointAuthMethodsSupported.length > 0
+      && !metadata.tokenEndpointAuthMethodsSupported.includes(requestedAuthMethod)) {
+    throw new Error(`OAuth 服务不支持 token_endpoint_auth_method=${requestedAuthMethod}`);
+  }
   const callback = await startCallbackServer({ path: '/callback', timeoutMs: config.callbackTimeoutMs, signal });
   const registration = await registerClient(metadata.registrationEndpoint, {
     clientName: connector.auth.clientName,
     redirectUris: [callback.url],
     scope: connector.auth.scope,
+    tokenEndpointAuthMethod: requestedAuthMethod,
     timeoutMs: config.requestTimeoutMs,
   });
 
@@ -61,6 +67,8 @@ export async function oauthAuthorize({ connector, config, logger, signal }) {
 
   const token = await exchangeCode(metadata.tokenEndpoint, {
     clientId: registration.clientId,
+    clientSecret: registration.clientSecret,
+    tokenEndpointAuthMethod: registration.tokenEndpointAuthMethod,
     code,
     redirectUri: callback.url,
     codeVerifier: verifier,
@@ -83,6 +91,9 @@ export async function oauthAuthorize({ connector, config, logger, signal }) {
   return {
     issuer,
     clientId: registration.clientId,
+    clientSecret: registration.clientSecret,
+    clientSecretExpiresAt: registration.clientSecretExpiresAt,
+    tokenEndpointAuthMethod: registration.tokenEndpointAuthMethod,
     clientName: connector.auth.clientName,
     scope: connector.auth.scope,
     token,

--- a/lib/index.js
+++ b/lib/index.js
@@ -147,11 +147,17 @@ export async function apply(ctx, config) {
   async function refreshGrant(grantKey) {
     const entry = state.grants.get(grantKey);
     if (!entry || !entry.grant.refreshToken) throw new Error('no refresh token available');
+    if (entry.grant.clientSecret && entry.grant.clientSecretExpiresAt > 0
+        && entry.grant.clientSecretExpiresAt * 1000 <= Date.now()) {
+      throw new Error('OAuth dynamic client secret expired');
+    }
     if (entry.refreshPromise) return entry.refreshPromise;
     entry.refreshPromise = (async () => {
       const metadata = await discoverServerMetadata(entry.grant.issuer, config.requestTimeoutMs);
       const token = await refreshAccessToken(metadata.tokenEndpoint, {
         clientId: entry.grant.clientId,
+        clientSecret: entry.grant.clientSecret,
+        tokenEndpointAuthMethod: entry.grant.tokenEndpointAuthMethod ?? 'none',
         refreshToken: entry.grant.refreshToken,
         resource: entry.grant.authorizedResources[0],
         scope: entry.grant.scope,
@@ -204,6 +210,8 @@ export async function apply(ctx, config) {
         if (metadata.revocationEndpoint) {
           await revokeRefreshToken(metadata.revocationEndpoint, {
             clientId: entry.grant.clientId,
+            clientSecret: entry.grant.clientSecret,
+            tokenEndpointAuthMethod: entry.grant.tokenEndpointAuthMethod ?? 'none',
             refreshToken: entry.grant.refreshToken,
             timeoutMs: config.requestTimeoutMs,
           });
@@ -247,7 +255,9 @@ export async function apply(ctx, config) {
     const grantKey = record.auth.grantKey;
     const entry = grantKey ? state.grants.get(grantKey) : null;
     if (!entry) return { ok: false, kind: 'auth', serverKey: record.serverKey, serverName: record.serverName, message: 'OAuth 授权缺失，请重新授权' };
-    if (entry.needsReauth || entry.grant.accessTokenExpiresAt <= Date.now()) {
+    const clientSecretExpired = entry.grant.clientSecret && entry.grant.clientSecretExpiresAt > 0
+      && entry.grant.clientSecretExpiresAt * 1000 <= Date.now();
+    if (entry.needsReauth || clientSecretExpired || entry.grant.accessTokenExpiresAt <= Date.now()) {
       return { ok: false, kind: 'auth', serverKey: record.serverKey, serverName: record.serverName, message: 'OAuth 授权已过期或刷新失败，请重新授权' };
     }
     return null;
@@ -302,6 +312,35 @@ export async function apply(ctx, config) {
     return summary;
   }
 
+  function resolveCredentialValues(connector, params = {}) {
+    const raw = params.credentialValues && typeof params.credentialValues === 'object' && !Array.isArray(params.credentialValues)
+      ? params.credentialValues
+      : {};
+    const values = {};
+    const fields = connector.auth.credentialFields ?? [];
+    for (const [index, field] of fields.entries()) {
+      let value = raw[field.key];
+      // 兼容旧调用方：单一/首个凭据仍可通过 bearerToken 或 apiKeyValue 传入。
+      if ((value === undefined || value === '') && (field.key === 'credential' || index === 0)) {
+        value = connector.auth.mode === 'bearer' ? params.bearerToken : params.apiKeyValue;
+      }
+      if (field.required && (value === undefined || String(value).trim() === '')) {
+        throw new Error(`${field.label} 必填`);
+      }
+      if (value !== undefined && String(value) !== '') values[field.key] = String(value);
+    }
+    return values;
+  }
+
+  function bindStdioCredentials(server, credentialValues) {
+    const env = { ...(server.env ?? {}) };
+    for (const [envName, credentialKey] of Object.entries(server.credentialBindings ?? {})) {
+      const value = credentialValues[credentialKey];
+      if (value !== undefined && value !== '') env[envName] = value;
+    }
+    return env;
+  }
+
   /* ───────────────────────── api 门面 ───────────────────────── */
 
   const api = {
@@ -326,6 +365,7 @@ export async function apply(ctx, config) {
         credentialPlaceholder: d.auth.credentialPlaceholder,
         credentialDescription: d.auth.credentialDescription,
         credentialHelpLabel: d.auth.credentialHelpLabel,
+        credentialFields: d.auth.credentialFields ?? [],
         prompts: d.prompts ?? [],
         probeStatus: d.probeStatus,
         probeCheckedAt: d.probeCheckedAt,
@@ -340,6 +380,9 @@ export async function apply(ctx, config) {
         servers: (d.servers ?? []).map((s) => ({
           serverKey: s.serverKey,
           url: s.url,
+          command: s.command,
+          args: s.args,
+          credentialBindings: s.credentialBindings,
           transport: s.transport,
           serverName: s.serverName,
         })),
@@ -373,6 +416,9 @@ export async function apply(ctx, config) {
               key: grantKey,
               issuer: authz.issuer,
               clientId: authz.clientId,
+              clientSecret: authz.clientSecret,
+              clientSecretExpiresAt: authz.clientSecretExpiresAt,
+              tokenEndpointAuthMethod: authz.tokenEndpointAuthMethod ?? 'none',
               clientName: authz.clientName,
               scope: authz.scope,
               account: config.account,
@@ -466,8 +512,14 @@ export async function apply(ctx, config) {
         ok: false,
         message:
           `连接器 "${connector.name}" 需要凭据（${connector.auth.mode}），目录不含密钥。` +
-          `请用 mcp_connector_configure 提供：url=${connector.servers[0].url}, serverName=${connector.servers[0].serverName}`,
-        detail: { url: connector.servers[0].url, serverName: connector.servers[0].serverName },
+          '请用 mcp_connector_configure 在本机填写目录声明的凭据字段。',
+        detail: {
+          transport: connector.servers[0].transport,
+          url: connector.servers[0].url,
+          command: connector.servers[0].command,
+          serverName: connector.servers[0].serverName,
+          credentialFields: connector.auth.credentialFields ?? [],
+        },
       };
     },
 
@@ -481,17 +533,23 @@ export async function apply(ctx, config) {
             throw new Error(`连接器 "${connector.name}" 不是 Bearer/API Key 凭据型`);
           }
           const records = [];
+          const credentialValues = resolveCredentialValues(connector, params);
+          const primaryCredential = credentialValues[connector.auth.credentialFields?.[0]?.key ?? 'credential'];
           for (const server of connector.servers) {
             const record = buildManualRecord({
               name: connector.servers.length > 1 ? `${connector.name}·${server.serverKey}` : connector.name,
               url: server.url,
               serverName: server.serverName,
               transport: server.transport,
+              command: server.command,
+              args: server.args,
+              envJson: server.transport === 'stdio' ? bindStdioCredentials(server, credentialValues) : undefined,
+              cwd: server.cwd,
               headersJson: server.headers,
-              authMode: connector.auth.mode,
-              bearerToken: params.bearerToken,
+              authMode: server.transport === 'stdio' ? 'none' : connector.auth.mode,
+              bearerToken: params.bearerToken ?? primaryCredential,
               apiKeyHeader: params.apiKeyHeader || connector.auth.apiKeyHeader,
-              apiKeyValue: params.apiKeyValue,
+              apiKeyValue: params.apiKeyValue ?? primaryCredential,
             });
             record.key = `${connector.id}-${server.serverKey}`;
             record.connectorId = connector.id;
@@ -727,6 +785,8 @@ export async function apply(ctx, config) {
               if (metadata.revocationEndpoint) {
                 await revokeRefreshToken(metadata.revocationEndpoint, {
                   clientId: g.grant.clientId,
+                  clientSecret: g.grant.clientSecret,
+                  tokenEndpointAuthMethod: g.grant.tokenEndpointAuthMethod ?? 'none',
                   refreshToken: g.grant.refreshToken,
                   timeoutMs: config.requestTimeoutMs,
                 });

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -184,7 +184,13 @@ export async function discoverServerMetadata(issuer, timeoutMs) {
 
 /* ─────────────────────────── 阶段三：动态注册客户端 ─────────────────────────── */
 
-export async function registerClient(registrationEndpoint, { clientName, redirectUris, scope = DEFAULT_SCOPE, timeoutMs }) {
+export async function registerClient(registrationEndpoint, {
+  clientName,
+  redirectUris,
+  scope = DEFAULT_SCOPE,
+  tokenEndpointAuthMethod = 'none',
+  timeoutMs,
+}) {
   if (!Array.isArray(redirectUris) || redirectUris.length === 0) {
     throw new OAuthError('invalid_client_metadata', 'redirect_uris is required');
   }
@@ -198,7 +204,7 @@ export async function registerClient(registrationEndpoint, { clientName, redirec
         redirect_uris: redirectUris,
         grant_types: ['authorization_code', 'refresh_token'],
         response_types: ['code'],
-        token_endpoint_auth_method: 'none',
+        token_endpoint_auth_method: tokenEndpointAuthMethod,
         scope,
       }),
     },
@@ -207,7 +213,25 @@ export async function registerClient(registrationEndpoint, { clientName, redirec
   if (typeof body.client_id !== 'string' || body.client_id.length === 0) {
     throw new OAuthError('invalid_client_metadata', 'registration response missing client_id');
   }
-  return { clientId: body.client_id, clientIdIssuedAt: body.client_id_issued_at, clientName: body.client_name };
+  const resolvedAuthMethod = body.token_endpoint_auth_method ?? tokenEndpointAuthMethod;
+  if (!['none', 'client_secret_post', 'client_secret_basic'].includes(resolvedAuthMethod)) {
+    throw new OAuthError('invalid_client_metadata', `unsupported token_endpoint_auth_method: ${resolvedAuthMethod}`);
+  }
+  const clientSecret = typeof body.client_secret === 'string' && body.client_secret.length > 0
+    ? body.client_secret
+    : undefined;
+  if (resolvedAuthMethod !== 'none' && !clientSecret) {
+    throw new OAuthError('invalid_client_metadata', `registration response missing client_secret for ${resolvedAuthMethod}`);
+  }
+  const expiresAt = Number(body.client_secret_expires_at);
+  return {
+    clientId: body.client_id,
+    clientSecret,
+    clientSecretExpiresAt: Number.isFinite(expiresAt) ? expiresAt : undefined,
+    tokenEndpointAuthMethod: resolvedAuthMethod,
+    clientIdIssuedAt: body.client_id_issued_at,
+    clientName: body.client_name,
+  };
 }
 
 /* ─────────────────────────── PKCE ─────────────────────────── */
@@ -250,10 +274,43 @@ export function buildAuthorizeUrl(metadata, { clientId, redirectUri, state, chal
 
 /* ─────────────────────────── 阶段五：换 token / 刷新 / 撤销 ─────────────────────────── */
 
-export async function exchangeCode(tokenEndpoint, { clientId, code, redirectUri, codeVerifier, resource, scope, timeoutMs }) {
+function formComponent(value) {
+  return new URLSearchParams({ value: String(value) }).toString().slice('value='.length);
+}
+
+function clientAuthentication({ clientId, clientSecret, tokenEndpointAuthMethod = 'none' }) {
+  if (!clientId) throw new OAuthError('invalid_client', 'client_id is required');
+  if (tokenEndpointAuthMethod === 'none') {
+    return { params: { client_id: clientId }, headers: {} };
+  }
+  if (!clientSecret) {
+    throw new OAuthError('invalid_client', `client_secret is required for ${tokenEndpointAuthMethod}`);
+  }
+  if (tokenEndpointAuthMethod === 'client_secret_post') {
+    return { params: { client_id: clientId, client_secret: clientSecret }, headers: {} };
+  }
+  if (tokenEndpointAuthMethod === 'client_secret_basic') {
+    const encoded = Buffer.from(`${formComponent(clientId)}:${formComponent(clientSecret)}`).toString('base64');
+    return { params: {}, headers: { Authorization: `Basic ${encoded}` } };
+  }
+  throw new OAuthError('invalid_client', `unsupported token endpoint auth method: ${tokenEndpointAuthMethod}`);
+}
+
+export async function exchangeCode(tokenEndpoint, {
+  clientId,
+  clientSecret,
+  tokenEndpointAuthMethod = 'none',
+  code,
+  redirectUri,
+  codeVerifier,
+  resource,
+  scope,
+  timeoutMs,
+}) {
+  const clientAuth = clientAuthentication({ clientId, clientSecret, tokenEndpointAuthMethod });
   const params = {
     grant_type: 'authorization_code',
-    client_id: clientId,
+    ...clientAuth.params,
     code,
     redirect_uri: redirectUri,
     code_verifier: codeVerifier,
@@ -262,37 +319,53 @@ export async function exchangeCode(tokenEndpoint, { clientId, code, redirectUri,
   if (scope) params.scope = scope;
   const body = await fetchJson(
     tokenEndpoint,
-    { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body: formEncode(params) },
+    { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...clientAuth.headers }, body: formEncode(params) },
     timeoutMs,
   );
   return parseTokenResponse(body, scope);
 }
 
-export async function refreshAccessToken(tokenEndpoint, { clientId, refreshToken, resource, scope, timeoutMs }) {
+export async function refreshAccessToken(tokenEndpoint, {
+  clientId,
+  clientSecret,
+  tokenEndpointAuthMethod = 'none',
+  refreshToken,
+  resource,
+  scope,
+  timeoutMs,
+}) {
+  const clientAuth = clientAuthentication({ clientId, clientSecret, tokenEndpointAuthMethod });
   const params = {
     grant_type: 'refresh_token',
-    client_id: clientId,
+    ...clientAuth.params,
     refresh_token: refreshToken,
   };
   if (resource) params.resource = resource;
   if (scope) params.scope = scope;
   const body = await fetchJson(
     tokenEndpoint,
-    { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body: formEncode(params) },
+    { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...clientAuth.headers }, body: formEncode(params) },
     timeoutMs,
   );
   return parseTokenResponse(body, scope);
 }
 
-export async function revokeRefreshToken(revocationEndpoint, { clientId, refreshToken, timeoutMs }) {
+export async function revokeRefreshToken(revocationEndpoint, {
+  clientId,
+  clientSecret,
+  tokenEndpointAuthMethod = 'none',
+  refreshToken,
+  timeoutMs,
+}) {
+  const clientAuth = clientAuthentication({ clientId, clientSecret, tokenEndpointAuthMethod });
   assertSafeUrl(revocationEndpoint);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(new Error('timeout')), timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS);
   try {
     const response = await fetch(revocationEndpoint, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: formEncode({ client_id: clientId, token: refreshToken, token_type_hint: 'refresh_token' }),
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...clientAuth.headers },
+      body: formEncode({ ...clientAuth.params, token: refreshToken, token_type_hint: 'refresh_token' }),
       signal: controller.signal,
     });
     if (response.ok) return true;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -11,10 +11,22 @@ export const serverRefSchema = z.object({
   command: z.string().min(1).optional(),
   args: z.array(z.string()).optional(),
   env: z.record(z.string()).optional(),
+  credentialBindings: z.record(z.string()).optional(),
   cwd: z.string().optional(),
   serverName: z.string().min(1),
   transport: z.enum(['streamable-http', 'sse', 'stdio']).optional(),
   headers: z.record(z.string()).optional(),
+});
+
+/** 市场凭据输入定义；只描述表单，绝不包含真实值。 */
+export const credentialFieldSchema = z.object({
+  key: z.string().regex(/^[A-Za-z][A-Za-z0-9_-]*$/, '仅允许字母开头及字母/数字/_/-'),
+  label: z.string().min(1),
+  placeholder: z.string().optional(),
+  description: z.string().optional(),
+  helpLabel: z.string().optional(),
+  required: z.boolean().optional(),
+  secret: z.boolean().optional(),
 });
 
 /** Prompt 模板变量；目录只描述表单，不保存用户输入。 */
@@ -71,13 +83,14 @@ export const connectorDescriptorSchema = z.object({
       issuer: z.string().optional(),
       scope: z.string().optional(),
       clientName: z.string().optional(),
-      tokenEndpointAuthMethod: z.string().optional(),
+      tokenEndpointAuthMethod: z.enum(['none', 'client_secret_post', 'client_secret_basic']).optional(),
       apiKeyHeader: z.string().optional(),
       grantSharing: z.string().optional(),
       credentialName: z.string().optional(),
       credentialPlaceholder: z.string().optional(),
       credentialDescription: z.string().optional(),
       credentialHelpLabel: z.string().optional(),
+      credentialFields: z.array(credentialFieldSchema).optional(),
     })
     .optional(),
   servers: z.array(serverRefSchema).min(1),
@@ -118,6 +131,9 @@ export const grantRecordSchema = z.object({
   key: z.string().min(1),
   issuer: z.string().min(1),
   clientId: z.string().min(1),
+  clientSecret: z.string().optional(),
+  clientSecretExpiresAt: z.number().optional(),
+  tokenEndpointAuthMethod: z.enum(['none', 'client_secret_post', 'client_secret_basic']).optional(),
   clientName: z.string().optional(),
   scope: z.string(),
   account: z.string(),
@@ -160,12 +176,37 @@ export function normalizeConnectorDescriptor(raw) {
       command: transport === 'stdio' ? s.command : undefined,
       args: transport === 'stdio' ? (s.args ?? []) : undefined,
       env: transport === 'stdio' ? (s.env ?? {}) : undefined,
+      credentialBindings: transport === 'stdio' ? (s.credentialBindings ?? {}) : undefined,
       cwd: transport === 'stdio' ? (s.cwd ?? '') : undefined,
       serverName: s.serverName,
       transport,
       headers: transport === 'streamable-http' ? (s.headers ?? {}) : {},
     };
   });
+  const authMode = c.auth?.mode ?? 'none';
+  const fallbackCredentialLabel = c.auth?.credentialName
+    || (authMode === 'bearer' ? 'Bearer Token' : authMode === 'api-key' ? 'API Key' : '凭据');
+  const credentialFields = c.auth?.credentialFields?.length
+    ? c.auth.credentialFields.map((field) => ({
+        key: field.key,
+        label: field.label,
+        placeholder: field.placeholder ?? '',
+        description: field.description ?? '',
+        helpLabel: field.helpLabel ?? '',
+        required: field.required !== false,
+        secret: field.secret !== false,
+      }))
+    : ['bearer', 'api-key'].includes(authMode)
+      ? [{
+          key: 'credential',
+          label: fallbackCredentialLabel,
+          placeholder: c.auth?.credentialPlaceholder ?? '',
+          description: c.auth?.credentialDescription ?? '',
+          helpLabel: c.auth?.credentialHelpLabel ?? '',
+          required: true,
+          secret: true,
+        }]
+      : [];
   return {
     schemaVersion: c.schemaVersion ?? 1,
     id: c.id,
@@ -186,7 +227,7 @@ export function normalizeConnectorDescriptor(raw) {
     probeReportUrl: c.probeReportUrl ?? '',
     toolsSnapshot: c.toolsSnapshot ?? [],
     auth: {
-      mode: c.auth?.mode ?? 'none',
+      mode: authMode,
       issuer: c.auth?.issuer ?? '',
       scope: c.auth?.scope ?? 'mcp:tools',
       clientName: c.auth?.clientName ?? 'DeepSeek Harness - MCP 连接器',
@@ -197,6 +238,7 @@ export function normalizeConnectorDescriptor(raw) {
       credentialPlaceholder: c.auth?.credentialPlaceholder ?? '',
       credentialDescription: c.auth?.credentialDescription ?? '',
       credentialHelpLabel: c.auth?.credentialHelpLabel ?? '',
+      credentialFields,
     },
     servers,
   };

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -109,7 +109,8 @@ export function registerTools(ctx, api) {
     name: 'mcp_connector_configure',
     description:
       '自定义配置一个外部 MCP Server 连接：HTTP 可填写 URL/鉴权；stdio 可填写 command/args/env/cwd。' +
-      '也可对市场中的 Bearer/API Key 连接器按 connectorId 一次配置全部 Server；市场连接器会先验证 initialize 连通性与凭据，通过后才保存。',
+      '也可对市场中的 Bearer/API Key 连接器按 connectorId 一次配置全部 Server；stdio 凭据会按目录声明安全注入本机环境变量。' +
+      '市场连接器会先验证或交由 Host 托管，通过后才保存。',
     parameters: {
       type: 'object',
       properties: {
@@ -126,6 +127,11 @@ export function registerTools(ctx, api) {
         bearerToken: { type: 'string', description: 'authMode=bearer 时的 token' },
         apiKeyHeader: { type: 'string', description: 'authMode=api-key 时的头名，默认 X-Api-Key' },
         apiKeyValue: { type: 'string', description: 'authMode=api-key 时的值' },
+        credentialValues: {
+          type: 'object',
+          additionalProperties: { type: 'string' },
+          description: '市场 stdio 连接器声明的凭据字段值；只保存在本机，不写入目录',
+        },
         headersJson: { type: 'string', description: '额外静态头（JSON 对象字符串）' },
       },
       anyOf: [{ required: ['connectorId'] }, { required: ['name', 'url'] }, { required: ['name', 'transport', 'command'] }],

--- a/registry/catalog.json
+++ b/registry/catalog.json
@@ -79,7 +79,18 @@
         "credentialName": "北大法宝 Access Token",
         "credentialPlaceholder": "请输入您的北大法宝 Access Token",
         "credentialDescription": "用于访问北大法宝 MCP；仅保存在 DSH 本机。",
-        "credentialHelpLabel": "如何获取北大法宝 Token？"
+        "credentialHelpLabel": "如何获取北大法宝 Token？",
+        "credentialFields": [
+          {
+            "key": "credential",
+            "label": "北大法宝 Access Token",
+            "placeholder": "请输入您的北大法宝 Access Token",
+            "description": "用于访问北大法宝 MCP；仅保存在 DSH 本机。",
+            "helpLabel": "如何获取北大法宝 Token？",
+            "required": true,
+            "secret": true
+          }
+        ]
       },
       "servers": [
         {
@@ -211,7 +222,18 @@
         "credentialName": "Wind API Key（个人密钥）",
         "credentialPlaceholder": "请输入您的个人 Wind API Key",
         "credentialDescription": "用于访问 Wind MCP 的个人访问令牌；仅保存在 DSH 本机。",
-        "credentialHelpLabel": "如何获取 Wind API Key？"
+        "credentialHelpLabel": "如何获取 Wind API Key？",
+        "credentialFields": [
+          {
+            "key": "credential",
+            "label": "Wind API Key（个人密钥）",
+            "placeholder": "请输入您的个人 Wind API Key",
+            "description": "用于访问 Wind MCP 的个人访问令牌；仅保存在 DSH 本机。",
+            "helpLabel": "如何获取 Wind API Key？",
+            "required": true,
+            "secret": true
+          }
+        ]
       },
       "servers": [
         {

--- a/registry/connectors/stdio-credential.sample.json
+++ b/registry/connectors/stdio-credential.sample.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": 1,
+  "id": "vendor-local-service",
+  "name": "厂商·本地 MCP 示例",
+  "vendor": "厂商名称",
+  "icon": "🔐",
+  "category": "开发工具",
+  "summary": "演示市场凭据如何安全注入 stdio 环境变量",
+  "description": "目录只声明输入字段和环境变量映射；用户填写的真实值仅保存在 DSH 本机。",
+  "published": false,
+  "featured": false,
+  "homepage": "https://example.com/mcp",
+  "probeStatus": "unverified",
+  "auth": {
+    "mode": "api-key",
+    "credentialFields": [
+      {
+        "key": "apiToken",
+        "label": "服务 API Token",
+        "placeholder": "仅保存在 DSH 本机",
+        "description": "从服务控制台创建，不得提交到目录。",
+        "required": true,
+        "secret": true
+      },
+      {
+        "key": "region",
+        "label": "区域",
+        "placeholder": "例如 cn-east-1",
+        "required": true,
+        "secret": false
+      }
+    ]
+  },
+  "servers": [
+    {
+      "serverKey": "main",
+      "serverName": "vendor-local-service",
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@vendor/example-mcp-server"],
+      "env": {
+        "LOG_LEVEL": "info"
+      },
+      "credentialBindings": {
+        "VENDOR_API_TOKEN": "apiToken",
+        "VENDOR_REGION": "region"
+      }
+    }
+  ]
+}

--- a/registry/schema/connector.schema.json
+++ b/registry/schema/connector.schema.json
@@ -30,13 +30,17 @@
         "issuer": { "type": "string" },
         "scope": { "type": "string" },
         "clientName": { "type": "string" },
-        "tokenEndpointAuthMethod": { "type": "string" },
+        "tokenEndpointAuthMethod": { "enum": ["none", "client_secret_post", "client_secret_basic"] },
         "apiKeyHeader": { "type": "string" },
         "grantSharing": { "type": "string" },
         "credentialName": { "type": "string" },
         "credentialPlaceholder": { "type": "string" },
         "credentialDescription": { "type": "string" },
-        "credentialHelpLabel": { "type": "string" }
+        "credentialHelpLabel": { "type": "string" },
+        "credentialFields": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/credentialField" }
+        }
       }
     },
     "servers": {
@@ -52,6 +56,7 @@
           "command": { "type": "string", "minLength": 1 },
           "args": { "type": "array", "items": { "type": "string" } },
           "env": { "type": "object", "additionalProperties": { "type": "string" } },
+          "credentialBindings": { "type": "object", "additionalProperties": { "type": "string" } },
           "cwd": { "type": "string" },
           "serverName": { "type": "string", "minLength": 1 },
           "transport": { "enum": ["streamable-http", "stdio"] },
@@ -106,6 +111,20 @@
     }
   },
   "$defs": {
+    "credentialField": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "label"],
+      "properties": {
+        "key": { "type": "string", "pattern": "^[A-Za-z][A-Za-z0-9_-]*$" },
+        "label": { "type": "string", "minLength": 1 },
+        "placeholder": { "type": "string" },
+        "description": { "type": "string" },
+        "helpLabel": { "type": "string" },
+        "required": { "type": "boolean" },
+        "secret": { "type": "boolean" }
+      }
+    },
     "variables": {
       "type": "array",
       "items": {

--- a/test/mock-oauth-server.mjs
+++ b/test/mock-oauth-server.mjs
@@ -41,8 +41,14 @@ function readBody(req) {
  * @param {number} [options.expiresIn=3600]
  * @param {string[]} [options.tokenResources] 若提供，签发的 access_token 为带 resource claim 的 JWT（值传 server key 数组，如 ['company','risk',...]，模拟企业认证授权范围）
  * @param {boolean} [options.uniqueClientIds=false] 每次动态注册签发不同 client_id，用于验证重新授权后的旧 grant 清理
+ * @param {'none'|'client_secret_post'|'client_secret_basic'} [options.tokenEndpointAuthMethod='none'] DCR 返回的客户端鉴权方式
  */
-export function createMockQccServer({ expiresIn = 3600, tokenResources, uniqueClientIds = false } = {}) {
+export function createMockQccServer({
+  expiresIn = 3600,
+  tokenResources,
+  uniqueClientIds = false,
+  tokenEndpointAuthMethod = 'none',
+} = {}) {
   const state = {
     clientId: 'wb_dyn_mock_0001',
     registrationCount: 0,
@@ -52,6 +58,35 @@ export function createMockQccServer({ expiresIn = 3600, tokenResources, uniqueCl
     revokedRefresh: new Set(),
     expiresIn,
     tokenResources,
+    tokenEndpointAuthMethod,
+    clientSecret: 'mock-dynamic-client-secret',
+    clients: new Map(),
+    refreshCount: 0,
+    clientAuthMethods: [],
+  };
+
+  const decodeFormComponent = (value) => decodeURIComponent(String(value).replace(/\+/g, ' '));
+  const authenticateClient = (req, params) => {
+    let clientId;
+    let clientSecret;
+    if (tokenEndpointAuthMethod === 'client_secret_basic') {
+      const header = req.headers.authorization ?? '';
+      if (!header.startsWith('Basic ')) return null;
+      let decoded;
+      try { decoded = Buffer.from(header.slice(6), 'base64').toString('utf8'); } catch { return null; }
+      const colon = decoded.indexOf(':');
+      if (colon === -1) return null;
+      clientId = decodeFormComponent(decoded.slice(0, colon));
+      clientSecret = decodeFormComponent(decoded.slice(colon + 1));
+    } else {
+      clientId = params.get('client_id');
+      clientSecret = params.get('client_secret');
+    }
+    const registeredClient = state.clients.get(clientId);
+    if (!registeredClient) return null;
+    if (tokenEndpointAuthMethod !== 'none' && clientSecret !== registeredClient.clientSecret) return null;
+    state.clientAuthMethods.push(tokenEndpointAuthMethod);
+    return clientId;
   };
 
   /** 生成 access_token：tokenResources（server key 数组）提供时为 JWT（payload.resource），否则为普通字符串 */
@@ -82,7 +117,7 @@ export function createMockQccServer({ expiresIn = 3600, tokenResources, uniqueCl
         response_types_supported: ['code'],
         grant_types_supported: ['authorization_code', 'refresh_token'],
         code_challenge_methods_supported: ['S256'],
-        token_endpoint_auth_methods_supported: ['none'],
+        token_endpoint_auth_methods_supported: [tokenEndpointAuthMethod],
         scopes_supported: SCOPES,
       });
     }
@@ -122,18 +157,28 @@ export function createMockQccServer({ expiresIn = 3600, tokenResources, uniqueCl
         redirectUris: body.redirect_uris,
         grantTypes,
         responseTypes: body.response_types ?? ['code'],
+        tokenEndpointAuthMethod: body.token_endpoint_auth_method ?? 'none',
       };
+      if (state.registered.tokenEndpointAuthMethod !== tokenEndpointAuthMethod) {
+        return oauthError(res, 'invalid_client_metadata', `token_endpoint_auth_method must be ${tokenEndpointAuthMethod}`);
+      }
       state.registrationCount += 1;
       if (uniqueClientIds) state.clientId = `wb_dyn_mock_${String(state.registrationCount).padStart(4, '0')}`;
-      return json(res, 200, {
+      state.clients.set(state.clientId, { clientSecret: state.clientSecret, tokenEndpointAuthMethod });
+      const registration = {
         client_id: state.clientId,
         client_id_issued_at: Math.floor(Date.now() / 1000),
         client_name: body.client_name,
         redirect_uris: body.redirect_uris,
         grant_types: grantTypes,
         response_types: body.response_types ?? ['code'],
-        token_endpoint_auth_method: 'none',
-      });
+        token_endpoint_auth_method: tokenEndpointAuthMethod,
+      };
+      if (tokenEndpointAuthMethod !== 'none') {
+        registration.client_secret = state.clientSecret;
+        registration.client_secret_expires_at = 0;
+      }
+      return json(res, 200, registration);
     }
 
     // ── 授权页 ──
@@ -162,12 +207,14 @@ export function createMockQccServer({ expiresIn = 3600, tokenResources, uniqueCl
     // ── Token ──
     if (pathname === '/oauth/token' && req.method === 'POST') {
       const params = new URLSearchParams(await readBody(req));
+      const authenticatedClientId = authenticateClient(req, params);
+      if (!authenticatedClientId) return oauthError(res, 'invalid_client', 'client authentication failed', 401);
       const grantType = params.get('grant_type');
       if (grantType === 'authorization_code') {
         const code = params.get('code');
         const record = state.codes.get(code);
         if (!record || record.used) return oauthError(res, 'invalid_grant', 'authorization code invalid or already used');
-        if (record.clientId !== params.get('client_id')) return oauthError(res, 'invalid_grant', 'client_id mismatch');
+        if (record.clientId !== authenticatedClientId) return oauthError(res, 'invalid_grant', 'client_id mismatch');
         if (record.redirectUri !== params.get('redirect_uri')) return oauthError(res, 'invalid_grant', 'redirect_uri mismatch');
         const verifier = params.get('code_verifier');
         if (!verifier || sha256b64url(verifier) !== record.challenge) return oauthError(res, 'invalid_grant', 'PKCE verification failed');
@@ -186,11 +233,12 @@ export function createMockQccServer({ expiresIn = 3600, tokenResources, uniqueCl
       if (grantType === 'refresh_token') {
         const refreshToken = params.get('refresh_token');
         const record = state.refreshTokens.get(refreshToken);
-        if (!record || state.revokedRefresh.has(refreshToken) || record.clientId !== params.get('client_id')) {
+        if (!record || state.revokedRefresh.has(refreshToken) || record.clientId !== authenticatedClientId) {
           return oauthError(res, 'invalid_grant', 'refresh token invalid or expired');
         }
         // 轮换：作废旧 refresh token，签发新的一对（文档 §12.1）
         state.refreshTokens.delete(refreshToken);
+        state.refreshCount += 1;
         const newRefreshToken = randomBytes(24).toString('base64url');
         const accessToken = makeAccessToken();
         state.refreshTokens.set(newRefreshToken, { accessToken, clientId: record.clientId, expiresIn: state.expiresIn });
@@ -208,6 +256,7 @@ export function createMockQccServer({ expiresIn = 3600, tokenResources, uniqueCl
     // ── Revoke ──
     if (pathname === '/oauth/revoke' && req.method === 'POST') {
       const params = new URLSearchParams(await readBody(req));
+      if (!authenticateClient(req, params)) return oauthError(res, 'invalid_client', 'client authentication failed', 401);
       const token = params.get('token');
       if (params.get('token_type_hint') !== 'refresh_token') return oauthError(res, 'unsupported_token_type', 'only refresh_token hint supported');
       if (state.refreshTokens.has(token)) {

--- a/test/plugin-flow.test.mjs
+++ b/test/plugin-flow.test.mjs
@@ -172,6 +172,75 @@ test('OAuth 一键连接：授权 → 挂载 mcp-client 条目 → 状态', { ti
   await oauth.close();
 });
 
+test('OAuth DCR client_secret_post/basic：换取、刷新和撤销均使用动态客户端密钥且不对外泄露', { timeout: 30000 }, async () => {
+  for (const tokenEndpointAuthMethod of ['client_secret_post', 'client_secret_basic']) {
+    const oauth = await createMockQccServer({
+      tokenResources: ['company'],
+      tokenEndpointAuthMethod,
+    });
+    const { ctx, tools, logs, tables } = makePluginContext();
+    const { apply } = await import('../lib/index.js');
+    const connector = {
+      id: `oauth-${tokenEndpointAuthMethod}`,
+      name: `OAuth ${tokenEndpointAuthMethod}`,
+      category: '开发工具',
+      auth: {
+        mode: 'oauth2-pkce',
+        issuer: oauth.base,
+        scope: 'mcp:tools',
+        clientName: 'dcr-secret-test',
+        tokenEndpointAuthMethod,
+      },
+      servers: [{
+        serverKey: 'company',
+        url: `${oauth.base}/mcp/company/stream`,
+        serverName: `oauth-${tokenEndpointAuthMethod}`,
+        transport: 'streamable-http',
+        headers: {},
+      }],
+    };
+
+    try {
+      await apply(ctx, baseConfig({ connectors: [connector] }));
+      const pending = tools.defs.get('mcp_connector_connect').execute({ connectorId: connector.id }, { signal: undefined });
+      await autoApprove(logs);
+      const connected = await pending;
+      assert.equal(connected.ok, true, connected.message);
+
+      const grants = [...tables.get('grants').entries()];
+      assert.equal(grants.length, 1);
+      assert.equal(grants[0][1].clientSecret, oauth.state.clientSecret);
+      assert.equal(grants[0][1].tokenEndpointAuthMethod, tokenEndpointAuthMethod);
+
+      const catalog = await tools.defs.get('mcp_connector_catalog').execute({ keyword: connector.id });
+      const status = await tools.defs.get('mcp_connector_status').execute({});
+      const publicOutput = JSON.stringify({ connected, catalog, status, logs });
+      assert.doesNotMatch(publicOutput, new RegExp(oauth.state.clientSecret));
+
+      const { discoverServerMetadata, refreshAccessToken } = await import('../lib/oauth.js');
+      const metadata = await discoverServerMetadata(oauth.base, 5000);
+      const refreshed = await refreshAccessToken(metadata.tokenEndpoint, {
+        clientId: grants[0][1].clientId,
+        clientSecret: grants[0][1].clientSecret,
+        tokenEndpointAuthMethod: grants[0][1].tokenEndpointAuthMethod,
+        refreshToken: grants[0][1].refreshToken,
+        resource: grants[0][1].authorizedResources[0],
+        scope: grants[0][1].scope,
+        timeoutMs: 5000,
+      });
+      assert.ok(refreshed.accessToken.length > 0);
+      assert.equal(oauth.state.refreshCount, 1);
+
+      const disconnected = await tools.defs.get('mcp_connector_disconnect').execute({ key: `${connector.id}-company` }, { signal: undefined });
+      assert.equal(disconnected.ok, true, disconnected.message);
+      assert.ok(oauth.state.clientAuthMethods.length >= 3, '应至少覆盖 code exchange、refresh、revoke');
+      assert.ok(oauth.state.clientAuthMethods.every((method) => method === tokenEndpointAuthMethod));
+    } finally {
+      await oauth.close();
+    }
+  }
+});
+
 test('同一连接器并发点击 OAuth 连接时只发起一次授权', { timeout: 30000 }, async () => {
   const oauth = await createMockQccServer({ tokenResources: ['company'] });
   const { ctx, tools, logs, tables } = makePluginContext();
@@ -417,6 +486,74 @@ test('stdio 市场连接、自定义配置与 JSON 导入均透传给 dsh-mcp-cl
   assert.equal(imported.ok, true, imported.message);
   assert.equal(loader.entries.get('mcp-json-memory').options.config.transport, 'stdio');
   assert.equal(loader.entries.get('mcp-json-memory').options.config.command, 'npx');
+});
+
+test('stdio 市场凭据绑定：多字段只在本机注入 env，目录和状态不返回真实值', { timeout: 15000 }, async () => {
+  const connector = {
+    id: 'stdio-secure-market',
+    name: 'Stdio Secure Market',
+    auth: {
+      mode: 'api-key',
+      credentialFields: [
+        { key: 'apiToken', label: 'API Token', required: true, secret: true },
+        { key: 'region', label: '区域', required: true, secret: false },
+      ],
+    },
+    servers: [{
+      serverKey: 'main',
+      transport: 'stdio',
+      serverName: 'stdio-secure-market',
+      command: 'uvx',
+      args: ['vendor-mcp'],
+      env: { LOG_LEVEL: 'info' },
+      credentialBindings: { VENDOR_API_TOKEN: 'apiToken', VENDOR_REGION: 'region' },
+    }],
+  };
+  const { ctx, loader, tools, tables, logs } = makePluginContext();
+  const { apply } = await import('../lib/index.js');
+  await apply(ctx, baseConfig({ connectors: [connector] }));
+
+  const connect = await tools.defs.get('mcp_connector_connect').execute({ connectorId: connector.id }, { signal: undefined });
+  assert.equal(connect.ok, false);
+  assert.equal(connect.detail.transport, 'stdio');
+  assert.equal(connect.detail.command, 'uvx');
+  assert.equal(connect.detail.credentialFields.length, 2);
+
+  const missing = await tools.defs.get('mcp_connector_configure').execute({
+    connectorId: connector.id,
+    credentialValues: { apiToken: 'stdio-local-secret' },
+  });
+  assert.equal(missing.ok, false);
+  assert.match(missing.message, /区域 必填/);
+  assert.equal([...tables.get('connections').entries()].length, 0);
+
+  const configured = await tools.defs.get('mcp_connector_configure').execute({
+    connectorId: connector.id,
+    credentialValues: { apiToken: 'stdio-local-secret', region: 'cn-east-1' },
+  });
+  assert.equal(configured.ok, true, configured.message);
+  assert.deepEqual(loader.entries.get('mcp-stdio-secure-market-main').options.config, {
+    transport: 'stdio',
+    serverName: 'stdio-secure-market',
+    command: 'uvx',
+    args: ['vendor-mcp'],
+    env: {
+      LOG_LEVEL: 'info',
+      VENDOR_API_TOKEN: 'stdio-local-secret',
+      VENDOR_REGION: 'cn-east-1',
+    },
+    cwd: process.cwd(),
+    failOnStartupError: false,
+  });
+  assert.equal([...tables.get('connections').entries()][0][1].env.VENDOR_API_TOKEN, 'stdio-local-secret');
+
+  const catalog = await tools.defs.get('mcp_connector_catalog').execute({ keyword: connector.id });
+  const status = await tools.defs.get('mcp_connector_status').execute({});
+  assert.deepEqual(catalog.detail.items[0].servers[0].credentialBindings, {
+    VENDOR_API_TOKEN: 'apiToken',
+    VENDOR_REGION: 'region',
+  });
+  assert.doesNotMatch(JSON.stringify({ connect, configured, catalog, status, logs }), /stdio-local-secret/);
 });
 
 test('市场 Bearer 连接器一次填写凭据批量连接全部 Server', { timeout: 15000 }, async () => {

--- a/test/schema.test.mjs
+++ b/test/schema.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { normalizeConnectorDescriptor, normalizeConnectionRecord } from '../lib/schema.js';
-import { auditDescriptor } from '../lib/catalog.js';
+import { auditDescriptor, auditRawDescriptor } from '../lib/catalog.js';
 import { normalizeJsonImport } from '../lib/connectors/json-connector.js';
 import { buildManualRecord } from '../lib/connectors/manual-connector.js';
 import { resourceMetadataUrlFallback } from '../lib/oauth.js';
@@ -48,6 +48,15 @@ test('normalizeConnectorDescriptor 接受参数化 Prompt 与工具快照', () =
   assert.equal(d.auth.credentialPlaceholder, '请输入 Token');
   assert.equal(d.auth.credentialDescription, '仅保存在本机');
   assert.equal(d.auth.credentialHelpLabel, '如何获取 Token？');
+  assert.deepEqual(d.auth.credentialFields, [{
+    key: 'credential',
+    label: 'Vendor Access Token',
+    placeholder: '请输入 Token',
+    description: '仅保存在本机',
+    helpLabel: '如何获取 Token？',
+    required: true,
+    secret: true,
+  }]);
   assert.equal(d.probeStatus, 'pass');
   assert.equal(d.toolsSnapshot[0].tools[0].name, 'search');
 });
@@ -146,6 +155,40 @@ test('stdio 描述校验、SSE 归一化与目录 env 密钥审计', () => {
     id: 'secret-env', name: 'Secret env', auth: { mode: 'none' },
     servers: [{ serverKey: 'main', transport: 'stdio', command: 'npx', env: { GITHUB_TOKEN: 'x' }, serverName: 'secret-env' }],
   })), /env.*密钥类变量/);
+});
+
+test('stdio 市场凭据仅声明字段和 env 绑定，支持多字段且拒绝错误引用', () => {
+  const raw = {
+    id: 'stdio-credential', name: 'Stdio Credential',
+    auth: {
+      mode: 'api-key',
+      credentialFields: [
+        { key: 'apiToken', label: 'API Token', required: true, secret: true },
+        { key: 'region', label: '区域', required: true, secret: false },
+      ],
+    },
+    servers: [{
+      serverKey: 'main', transport: 'stdio', command: 'uvx', args: ['vendor-mcp'],
+      env: { LOG_LEVEL: 'info' },
+      credentialBindings: { VENDOR_API_TOKEN: 'apiToken', VENDOR_REGION: 'region' },
+      serverName: 'stdio-credential',
+    }],
+  };
+  assert.doesNotThrow(() => auditRawDescriptor(raw));
+  const descriptor = auditDescriptor(normalizeConnectorDescriptor(raw));
+  assert.deepEqual(descriptor.servers[0].credentialBindings, {
+    VENDOR_API_TOKEN: 'apiToken',
+    VENDOR_REGION: 'region',
+  });
+  assert.equal(descriptor.auth.credentialFields[1].secret, false);
+
+  const unknown = structuredClone(raw);
+  unknown.servers[0].credentialBindings.VENDOR_API_TOKEN = 'missing';
+  assert.throws(() => auditDescriptor(normalizeConnectorDescriptor(unknown)), /未知凭据字段/);
+
+  const staticSecret = structuredClone(raw);
+  staticSecret.servers[0].env.VENDOR_API_TOKEN = 'must-not-be-in-catalog';
+  assert.throws(() => auditDescriptor(normalizeConnectorDescriptor(staticSecret)), /env.*密钥类变量/);
 });
 
 test('旧 connection record 的 SSE 归一化，stdio 字段保留', () => {

--- a/test/ui.test.mjs
+++ b/test/ui.test.mjs
@@ -58,7 +58,10 @@ test('凭据型市场卡片提供多 Server 一次配置表单', () => {
   assert.match(uiSource, /preset\.credentialPlaceholder/);
   assert.match(uiSource, /preset\.credentialDescription/);
   assert.match(uiSource, /preset\.credentialHelpLabel/);
-  assert.match(uiSource, /connectorId,\s*authMode,\s*bearerToken/);
+  assert.match(uiSource, /preset\.credentialFields/);
+  assert.match(uiSource, /data-credential-key=/);
+  assert.match(uiSource, /field\.secret === false \? 'text' : 'password'/);
+  assert.match(uiSource, /connectorId,\s*authMode,\s*credentialValues,\s*bearerToken/);
 });
 
 test('详情页的 Bearer/API Key 连接按钮直接打开凭据表单', () => {

--- a/ui/index.html
+++ b/ui/index.html
@@ -924,15 +924,31 @@
   function openCatalogCredentialForm(preset) {
     const authMode = preset.authMode === 'api-key' ? 'api-key' : 'bearer';
     const servers = preset.servers || [];
+    const usesStdio = servers.some((server) => server.transport === 'stdio');
     const homepage = /^https:\/\//i.test(preset.homepage || '') ? preset.homepage : '';
     const credentialName = preset.credentialName || (authMode === 'bearer' ? 'Bearer Token' : 'API Key');
     const credentialPlaceholder = preset.credentialPlaceholder || '仅保存在 DSH 本机';
     const credentialDescription = preset.credentialDescription || '凭据仅保存在 DSH 本机，不会写入市场目录或对话。';
     const credentialHelpLabel = preset.credentialHelpLabel || `前往 ${preset.vendor || preset.name} 官网获取`;
-    const credentialFields = authMode === 'bearer'
-      ? `<label for="cfg-token">${esc(credentialName)}（必填）</label><input id="cfg-token" type="password" autocomplete="off" placeholder="${esc(credentialPlaceholder)}" /><div class="field-help">${esc(credentialDescription)}</div>`
-      : `<div class="form-row"><div><label for="cfg-key-header">API Key Header</label><input id="cfg-key-header" value="${esc(preset.apiKeyHeader || 'X-Api-Key')}" /></div><div><label for="cfg-key-value">${esc(credentialName)}（必填）</label><input id="cfg-key-value" type="password" autocomplete="off" placeholder="${esc(credentialPlaceholder)}" /></div></div><div class="field-help">${esc(credentialDescription)}</div>`;
-    const serverPreview = servers.map((server) => `<div>${esc(server.serverName)} · ${esc(server.url)}</div>`).join('');
+    const declaredFields = preset.credentialFields?.length ? preset.credentialFields : [{
+      key: 'credential', label: credentialName, placeholder: credentialPlaceholder,
+      description: credentialDescription, required: true, secret: true,
+    }];
+    const stdioCredentialFields = declaredFields.map((field) => {
+      const id = `cfg-credential-${field.key}`;
+      return `<label for="${esc(id)}">${esc(field.label)}${field.required === false ? '（可选）' : '（必填）'}</label><input id="${esc(id)}" data-credential-key="${esc(field.key)}" type="${field.secret === false ? 'text' : 'password'}" autocomplete="off" placeholder="${esc(field.placeholder || '仅保存在 DSH 本机')}" />${field.description ? `<div class="field-help">${esc(field.description)}</div>` : ''}`;
+    }).join('');
+    const credentialFields = usesStdio
+      ? stdioCredentialFields
+      : authMode === 'bearer'
+        ? `<label for="cfg-token">${esc(credentialName)}（必填）</label><input id="cfg-token" type="password" autocomplete="off" placeholder="${esc(credentialPlaceholder)}" /><div class="field-help">${esc(credentialDescription)}</div>`
+        : `<div class="form-row"><div><label for="cfg-key-header">API Key Header</label><input id="cfg-key-header" value="${esc(preset.apiKeyHeader || 'X-Api-Key')}" /></div><div><label for="cfg-key-value">${esc(credentialName)}（必填）</label><input id="cfg-key-value" type="password" autocomplete="off" placeholder="${esc(credentialPlaceholder)}" /></div></div><div class="field-help">${esc(credentialDescription)}</div>`;
+    const serverPreview = servers.map((server) => {
+      const endpoint = server.transport === 'stdio'
+        ? `stdio · ${server.command || ''} ${(server.args || []).join(' ')}`.trim()
+        : server.url;
+      return `<div>${esc(server.serverName)} · ${esc(endpoint)}</div>`;
+    }).join('');
     openModal(`配置 ${preset.name}`, `
       <input id="cfg-connector-id" type="hidden" value="${esc(preset.id)}" />
       <input id="cfg-auth" type="hidden" value="${esc(authMode)}" />
@@ -1067,10 +1083,15 @@
       const connectorId = $('#cfg-connector-id')?.value.trim();
       const authMode = $('#cfg-auth').value;
       if (connectorId) {
+        const credentialValues = {};
+        document.querySelectorAll('[data-credential-key]').forEach((input) => {
+          credentialValues[input.dataset.credentialKey] = input.value;
+        });
         setModalBusy(true, '正在验证凭据与连接…');
         const r = await call('configure', {
           connectorId,
           authMode,
+          credentialValues,
           bearerToken: $('#cfg-token')?.value || undefined,
           apiKeyHeader: $('#cfg-key-header')?.value || undefined,
           apiKeyValue: $('#cfg-key-value')?.value || undefined,


### PR DESCRIPTION
## Summary

- add declarative multi-field credential inputs and local env bindings for marketplace stdio connectors
- support OAuth DCR `client_secret_post` and `client_secret_basic` across code exchange, refresh, and revocation
- keep stdio credential values and DCR client secrets out of catalog, status, and logs
- synchronize UI, embedded Registry schema/sample, and user/maintainer documentation

## Verification

- `npm test` — 91/91 passed
- `npm run lint`
- `npm run registry:build`
- `npm run registry:validate`
- `node scripts/probe-connector.mjs registry/catalog.json --validate-only`
- `npm run verify-pack` — 47 files passed
- `git diff --check`