### PR TITLE
fix: add resilient registry catalog sources

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -71,7 +71,7 @@ The detailed [Chinese user guide](docs/USER-GUIDE.md) covers category browsing, 
 
 ## Connector catalog
 
-The package contains a bundled fallback catalog. By default, it refreshes from the public [dsh-mcp-connector-registry](https://github.com/duhu2000/dsh-mcp-connector-registry); cached or bundled data remains available if the remote registry cannot be reached.
+The package contains a bundled fallback catalog. By default, it refreshes the public [dsh-mcp-connector-registry](https://github.com/duhu2000/dsh-mcp-connector-registry) through jsDelivr, then tries GitHub raw if the primary source fails; cached or bundled data remains available if neither remote source can be reached. jsDelivr branch URLs can lag behind a newly merged registry commit, so new cards may not appear immediately.
 
 The public connector registration process and descriptor requirements are documented in [docs/MARKET-REGISTRATION.md](docs/MARKET-REGISTRATION.md).
 The stdio architecture, passthrough boundary, and security constraints are documented in [docs/STDIO-SUPPORT.md](docs/STDIO-SUPPORT.md).
@@ -84,14 +84,14 @@ The default bundle configuration is in `cordis.patch.yml`:
 - id: mcp-connector
   name: dsh-mcp-connector
   config:
-    catalogUrl: 'https://raw.githubusercontent.com/duhu2000/dsh-mcp-connector-registry/main/catalog.json'
+    catalogUrl: 'https://cdn.jsdelivr.net/gh/duhu2000/dsh-mcp-connector-registry@main/catalog.json'
     persistSecrets: true
     entryPrefix: mcp
     refreshSkewMs: 300000
     openBrowser: true
 ```
 
-Set `catalogUrl` to an empty string for an explicitly offline/private setup.
+Set `catalogUrl` to an empty string for an explicitly offline/private setup. A custom non-default URL is used as-is and does not fall back to the public registry.
 
 ## Development and release checks
 

--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ Bundle 默认配置位于 `cordis.patch.yml`：
 - id: mcp-connector
   name: dsh-mcp-connector
   config:
-    catalogUrl: 'https://raw.githubusercontent.com/duhu2000/dsh-mcp-connector-registry/main/catalog.json'
+    catalogUrl: 'https://cdn.jsdelivr.net/gh/duhu2000/dsh-mcp-connector-registry@main/catalog.json'
     persistSecrets: true
     entryPrefix: mcp
     refreshSkewMs: 300000
     openBrowser: true
 ```
 
-`catalogUrl` 默认指向公共 [dsh-mcp-connector-registry](https://github.com/duhu2000/dsh-mcp-connector-registry)，支持 ETag/TTL 缓存；拉取失败时继续使用上次缓存或随包内置目录。需要离线/私有模式时可将其显式设为空字符串。
+`catalogUrl` 默认通过 jsDelivr CDN 读取公共 [dsh-mcp-connector-registry](https://github.com/duhu2000/dsh-mcp-connector-registry)，支持 ETag/TTL 缓存；主源失败时自动尝试 GitHub raw 备用源，再回退到上次缓存或随包内置目录。jsDelivr 的分支 URL 可能存在缓存延迟，因此 Registry 合并后的新卡片不保证秒级出现。需要离线/私有模式时可将 `catalogUrl` 显式设为空字符串；显式配置其他目录 URL 时不会自动切换到公共备用源。
 
 ## 开发与发布门禁
 

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -5,7 +5,7 @@
     - id: mcp-connector
       name: 'dsh-mcp-connector'
       config:
-        catalogUrl: 'https://raw.githubusercontent.com/duhu2000/dsh-mcp-connector-registry/main/catalog.json'
+        catalogUrl: 'https://cdn.jsdelivr.net/gh/duhu2000/dsh-mcp-connector-registry@main/catalog.json'
         persistSecrets: true
         entryPrefix: 'mcp'
         refreshSkewMs: 300000

--- a/docs/MARKET-REGISTRATION.md
+++ b/docs/MARKET-REGISTRATION.md
@@ -25,7 +25,7 @@ Bearer/API Key 型连接器可在卡片上点「配置」，一次填写凭据�
 3. 提交 PR。CI 会检查 Schema、重复 id/serverName、密钥、URL、MCP initialize、OAuth 元数据和图标。
 4. 合并后 CI 重建根目录 `catalog.json`；客户端点击“刷新”后可见，无需重新发布 `dsh-mcp-connector` npm 包。
 
-插件默认读取 `https://raw.githubusercontent.com/duhu2000/dsh-mcp-connector-registry/main/catalog.json`；远程不可用时自动回退上次缓存或随包内置目录。
+插件默认通过 `https://cdn.jsdelivr.net/gh/duhu2000/dsh-mcp-connector-registry@main/catalog.json` 读取目录；主源失败时依次尝试 GitHub raw 备用源、上次缓存和随包内置目录。jsDelivr 的分支 URL 存在缓存延迟，合并后的新卡片可能不会秒级出现。
 
 ## 4. DSH 外部插件市场验收
 

--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -134,6 +134,28 @@ export async function fetchRemoteCatalog(catalogUrl, { requestTimeoutMs, etag } 
   }
 }
 
+/**
+ * 按顺序拉取远程 registry。仅主源使用缓存 ETag；备用源总是全量拉取，
+ * 且不返回备用源 ETag，避免下一次请求把它误发给主源。
+ */
+export async function fetchRemoteCatalogWithFallback(catalogUrl, fallbackUrls = [], opts = {}) {
+  const urls = [catalogUrl, ...fallbackUrls].filter(Boolean);
+  let lastError;
+  for (let index = 0; index < urls.length; index += 1) {
+    try {
+      const fetched = await fetchRemoteCatalog(urls[index], {
+        requestTimeoutMs: opts.requestTimeoutMs,
+        etag: index === 0 ? opts.etag : undefined,
+      });
+      return index === 0 ? fetched : { ...fetched, etag: undefined };
+    } catch (error) {
+      lastError = error;
+      opts.onSourceError?.({ index, error });
+    }
+  }
+  throw lastError ?? new Error('catalog fetch failed for all sources');
+}
+
 /** 合并多层来源（sources 为低→高优先级的 descriptor 数组），再应用本地覆盖。 */
 export function mergeCatalog(sources, overrides = new Map()) {
   const merged = new Map();

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -16,9 +16,16 @@ export const JSON_CONNECTOR_ID = '__json__';
 /** 保留 id 前缀：社区 PR 注册表拒绝占用 */
 export const RESERVED_ID_PREFIXES = ['qcc-', 'dsh-', 'mcp-connector-'];
 
-/** 请求 / 刷新默认值 */
+/** 远程 registry 主目录源（jsDelivr CDN，国内网络更稳定） */
 export const DEFAULT_CATALOG_URL =
-  'https://raw.githubusercontent.com/duhu2000/dsh-mcp-connector-registry/main/catalog.json';
+  'https://cdn.jsdelivr.net/gh/duhu2000/dsh-mcp-connector-registry@main/catalog.json';
+
+/** 默认目录源失败时依次尝试；仅用于未自定义 catalogUrl 的配置。 */
+export const DEFAULT_CATALOG_FALLBACK_URLS = [
+  'https://raw.githubusercontent.com/duhu2000/dsh-mcp-connector-registry/main/catalog.json',
+];
+
+/** 请求 / 刷新默认值 */
 export const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
 export const DEFAULT_REFRESH_SKEW_MS = 300_000;
 export const DEFAULT_CATALOG_TTL_MS = 3_600_000;

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,13 +13,14 @@ import z from '@deepseek-ai/schemastery';
 import {
   DEFAULT_ACCOUNT,
   DEFAULT_CATALOG_URL,
+  DEFAULT_CATALOG_FALLBACK_URLS,
   DEFAULT_REQUEST_TIMEOUT_MS,
   DEFAULT_REFRESH_SKEW_MS,
   DEFAULT_CATALOG_TTL_MS,
 } from './constants.js';
 import { defineConnectorDomain, ConnectionStore, GrantStore, CatalogStore } from './stores.js';
 import { normalizeConnectorDescriptor, normalizeConnectionRecord } from './schema.js';
-import { loadBundledCatalog, fetchRemoteCatalog, mergeCatalog, listCatalog, auditDescriptor, auditRawDescriptor, readLimitedJson } from './catalog.js';
+import { loadBundledCatalog, fetchRemoteCatalogWithFallback, mergeCatalog, listCatalog, auditDescriptor, auditRawDescriptor, readLimitedJson } from './catalog.js';
 import { oauthAuthorize } from './connectors/oauth-connector.js';
 import { buildManualRecord } from './connectors/manual-connector.js';
 import { normalizeJsonImport } from './connectors/json-connector.js';
@@ -91,6 +92,15 @@ export async function apply(ctx, config) {
     state.merged = mergeCatalog(sources, state.overrides);
   }
 
+  function catalogFallbackUrls() {
+    return config.catalogUrl === DEFAULT_CATALOG_URL ? DEFAULT_CATALOG_FALLBACK_URLS : [];
+  }
+
+  function warnCatalogSourceFailure({ index, error }) {
+    const source = index === 0 ? 'primary' : `fallback ${index}`;
+    logger.warn(`catalog fetch ${source} failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
   async function loadCatalog() {
     const dynamicRec = await catalogStore.getDynamic().catch(() => null);
     if (dynamicRec?.connectors) {
@@ -116,10 +126,15 @@ export async function apply(ctx, config) {
     if (config.catalogUrl) {
       const cached = await catalogStore.getRemote().catch(() => null);
       try {
-        const fetched = await fetchRemoteCatalog(config.catalogUrl, {
-          requestTimeoutMs: config.requestTimeoutMs,
-          etag: cached?.etag,
-        });
+        const fetched = await fetchRemoteCatalogWithFallback(
+          config.catalogUrl,
+          catalogFallbackUrls(),
+          {
+            requestTimeoutMs: config.requestTimeoutMs,
+            etag: cached?.etag,
+            onSourceError: warnCatalogSourceFailure,
+          },
+        );
         if (fetched.notModified) {
           state.remoteConnectors = cached?.connectors ?? [];
         } else {
@@ -816,7 +831,14 @@ export async function apply(ctx, config) {
         return { ok: true, message: `市场已刷新，共 ${visibleCount} 个连接器` };
       }
       try {
-        const fetched = await fetchRemoteCatalog(config.catalogUrl, { requestTimeoutMs: config.requestTimeoutMs });
+        const fetched = await fetchRemoteCatalogWithFallback(
+          config.catalogUrl,
+          catalogFallbackUrls(),
+          {
+            requestTimeoutMs: config.requestTimeoutMs,
+            onSourceError: warnCatalogSourceFailure,
+          },
+        );
         state.remoteConnectors = fetched.connectors;
         await catalogStore.putRemote({ etag: fetched.etag, connectors: fetched.connectors }).catch(() => {});
         await recomputeMerged();

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -1,7 +1,14 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createServer } from 'node:http';
-import { loadBundledCatalog, listCatalog, mergeCatalog, fetchRemoteCatalog, readLimitedJson } from '../lib/catalog.js';
+import {
+  loadBundledCatalog,
+  listCatalog,
+  mergeCatalog,
+  fetchRemoteCatalog,
+  fetchRemoteCatalogWithFallback,
+  readLimitedJson,
+} from '../lib/catalog.js';
 import { normalizeConnectorDescriptor } from '../lib/schema.js';
 
 function desc(id, { published = true, featured = false, category = '其他' } = {}) {
@@ -87,6 +94,73 @@ test('fetchRemoteCatalog 拉取并解析 { connectors } 结构', async () => {
     assert.equal(result.notModified, false);
     assert.equal(result.connectors.length, 1);
     assert.equal(result.connectors[0].id, 'remote-a');
+  } finally {
+    server.close();
+  }
+});
+
+test('fetchRemoteCatalogWithFallback 主源失败后改用备用源且不混用 ETag', async () => {
+  const requests = [];
+  const server = createServer((req, res) => {
+    requests.push({ url: req.url, etag: req.headers['if-none-match'] });
+    if (req.url === '/primary.json') {
+      res.writeHead(503, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'unavailable' }));
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json', ETag: '"fallback-v1"' });
+    res.end(JSON.stringify({ connectors: [{ id: 'fallback-a', name: 'Fallback', servers: [{ serverKey: 'a', url: 'https://mcp.example.com/stream', serverName: 'fallback-a' }] }] }));
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = server.address().port;
+  const failures = [];
+  try {
+    const result = await fetchRemoteCatalogWithFallback(
+      `http://127.0.0.1:${port}/primary.json`,
+      [`http://127.0.0.1:${port}/fallback.json`],
+      {
+        requestTimeoutMs: 5000,
+        etag: '"primary-v1"',
+        onSourceError: (failure) => failures.push(failure),
+      },
+    );
+    assert.equal(result.notModified, false);
+    assert.equal(result.connectors[0].id, 'fallback-a');
+    assert.equal(result.etag, undefined, '备用源 ETag 不应写入主源缓存');
+    assert.deepEqual(requests, [
+      { url: '/primary.json', etag: '"primary-v1"' },
+      { url: '/fallback.json', etag: undefined },
+    ]);
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0].index, 0);
+    assert.match(failures[0].error.message, /HTTP 503/);
+  } finally {
+    server.close();
+  }
+});
+
+test('fetchRemoteCatalogWithFallback 主源 304 时不请求备用源', async () => {
+  const requests = [];
+  const server = createServer((req, res) => {
+    requests.push(req.url);
+    if (req.url === '/primary.json') {
+      res.writeHead(304);
+      res.end();
+      return;
+    }
+    res.writeHead(500);
+    res.end();
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = server.address().port;
+  try {
+    const result = await fetchRemoteCatalogWithFallback(
+      `http://127.0.0.1:${port}/primary.json`,
+      [`http://127.0.0.1:${port}/fallback.json`],
+      { requestTimeoutMs: 5000, etag: '"primary-v1"' },
+    );
+    assert.deepEqual(result, { notModified: true });
+    assert.deepEqual(requests, ['/primary.json']);
   } finally {
     server.close();
   }

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -1,17 +1,32 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
-import { DEFAULT_CATALOG_URL } from '../lib/constants.js';
+import { DEFAULT_CATALOG_FALLBACK_URLS, DEFAULT_CATALOG_URL } from '../lib/constants.js';
 import { Config } from '../lib/index.js';
 
 test('default config uses the independent public registry', () => {
   assert.equal(
     DEFAULT_CATALOG_URL,
-    'https://raw.githubusercontent.com/duhu2000/dsh-mcp-connector-registry/main/catalog.json',
+    'https://cdn.jsdelivr.net/gh/duhu2000/dsh-mcp-connector-registry@main/catalog.json',
   );
+  assert.deepEqual(DEFAULT_CATALOG_FALLBACK_URLS, [
+    'https://raw.githubusercontent.com/duhu2000/dsh-mcp-connector-registry/main/catalog.json',
+  ]);
   assert.equal(Config({}).catalogUrl, DEFAULT_CATALOG_URL);
 });
 
 test('an explicit empty catalogUrl keeps bundled-only mode available', () => {
   assert.equal(Config({ catalogUrl: '' }).catalogUrl, '');
+});
+
+test('an explicit custom catalogUrl remains unchanged', () => {
+  const customUrl = 'https://registry.example.com/catalog.json';
+  assert.equal(Config({ catalogUrl: customUrl }).catalogUrl, customUrl);
+});
+
+test('bundle patch uses the same jsDelivr primary catalog source', () => {
+  const patch = readFileSync(new URL('../cordis.patch.yml', import.meta.url), 'utf8');
+  assert.match(patch, new RegExp(DEFAULT_CATALOG_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  assert.doesNotMatch(patch, /catalogUrl:\s*['"]https:\/\/raw\.githubusercontent\.com/);
 });


### PR DESCRIPTION
## Summary

- switch the default Registry catalog source to jsDelivr for better reachability in mainland China
- keep GitHub raw as an ordered fallback when the default primary source fails
- use ETag revalidation only for the primary source and never persist a fallback-source ETag
- keep explicit custom `catalogUrl` values unchanged and isolated from the public fallback
- update the Cordis bundle patch so real DSH installations use the new primary source
- align Chinese and English documentation with the source order and cache behavior

## Verification

- `npm run check` — passed
- full test suite — 98/98 passed
- package verification — 47 publish files allowlisted; no credentials or local paths found
- fallback simulation — primary HTTP 503 correctly falls back; fallback request receives no primary ETag
- primary HTTP 304 — returns cached state without requesting the fallback
- live jsDelivr fetch — HTTP success with 66 connectors; all 5 PR A connectors are present

## Cache note

The Registry `main` branch currently contains 72 connectors, while jsDelivr still serves the prior 66-connector snapshot. This is consistent with jsDelivr branch caching (documented as up to 12 hours), so the fix resolves raw-source timeouts but does not promise immediate visibility after every Registry merge.

Official cache behavior: https://github.com/jsdelivr/jsdelivr#caching

## Release scope

- package version remains `0.2.19`
- no npm publish or GitHub Release is included in this PR
