### PR TITLE
release: prepare v0.2.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ## [Unreleased]
 
+## [0.2.20] - 2026-08-25
+
+### Changed
+
+- 默认公共 Registry 改用 jsDelivr CDN，并在主源请求失败时按顺序回退到 GitHub Raw，提升不同网络环境下远程市场目录的可用性。
+- DSH Bundle 补丁与插件默认配置统一使用 jsDelivr 主源；用户显式配置的自定义目录地址保持单一来源，不会被公共备用源覆盖。
+
+### Fixed
+
+- 主源与备用源分别处理缓存协商；备用源不会复用或写入主源 ETag，避免跨源缓存标识导致错误的 `304 Not Modified`。
+- 目录主源失败时记录逐源告警，并在备用源成功后继续刷新市场，避免一次网络故障导致远程目录完全不可用。
+
+### Verification
+
+- 插件 98 项自动测试、lint、npm 发布文件白名单/敏感内容扫描和 `git diff --check` 通过。
+- 新增主源失败回退、主源 `304` 不访问备用源、默认配置与 Bundle 配置一致，以及自定义目录不启用公共回退的回归测试。
+
 ## [0.2.19] - 2026-08-24
 
 ### Fixed
@@ -331,7 +348,8 @@
 - 外部 URL 与导入 Header 执行安全校验。
 - iframe 消息校验同源和消息来源。
 
-[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.19...HEAD
+[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.20...HEAD
+[0.2.20]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.19...v0.2.20
 [0.2.19]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.18...v0.2.19
 [0.2.18]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.17...v0.2.18
 [0.2.17]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.16...v0.2.17

--- a/README.en.md
+++ b/README.en.md
@@ -105,7 +105,7 @@ npm run dev:ui
 
 `npm run check` performs syntax checks, automated tests, and an npm package allowlist/sensitive-content audit. `npm run market:check` tracks the external DSH marketplace PR and live directory. Tags matching `v*` trigger GitHub Actions; the tag must match `package.json`. npm releases use Trusted Publishing through GitHub OIDC and do not require a long-lived `NPM_TOKEN`.
 
-The current public version is [`dsh-mcp-connector@0.2.19`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.19](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.19).
+The current public version is [`dsh-mcp-connector@0.2.20`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.20](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.20).
 
 See [CHANGELOG.md](CHANGELOG.md) for version history and [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md) for the Desktop release checklist.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ npm run dev:ui
 
 `check` 执行语法检查、自动测试和 npm 发布包白名单校验；`market:check` 检查外部 DSH 市场 PR 与线上目录；`dev:ui` 启动不含真实凭据的本地 mock 市场。CI 使用 `--legacy-peer-deps` 安装显式测试依赖，DSH 运行期 peer 仍由 Host 提供。`v*` Tag 会触发 GitHub Actions；Tag 必须与 `package.json` 版本一致。Release 通过 npm Trusted Publishing (GitHub OIDC) 发布，不依赖长期 `NPM_TOKEN`。
 
-当前公开版本为 [`dsh-mcp-connector@0.2.19`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.19](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.19)。
+当前公开版本为 [`dsh-mcp-connector@0.2.20`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.20](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.20)。
 
 版本能力与变更记录见 [CHANGELOG.md](CHANGELOG.md)。
 Desktop 发版回归见 [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mcp-connector",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "General-purpose MCP connector, connection manager, plugin extension, and integration marketplace for DeepSeek Harness, initiated and maintained by Qichacha/QCC.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## Summary

- bump package metadata and release documentation to `0.2.20`
- document the jsDelivr primary Registry source and GitHub Raw fallback
- record per-source ETag isolation, fallback behavior, and release verification

## Verification

- `npm run check`
- 98/98 automated tests passed
- 47 publish files passed allowlist and sensitive-content validation

After merge, the `v0.2.20` tag will trigger the existing Trusted Publishing workflow to publish npm and create the GitHub Release.