### PR TITLE
docs: sync live Registry connector counts

### DIFF
--- a/.github/workflows/sync-registry-stats.yml
+++ b/.github/workflows/sync-registry-stats.yml
@@ -1,0 +1,41 @@
+name: Sync Registry product stats
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '12 * * * *'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-registry-product-stats
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Fetch the authoritative Registry stats
+        run: npm run registry:stats:sync
+      - name: Verify generated files
+        run: |
+          node --test test/registry-stats-sync.test.mjs
+          git diff --check
+      - name: Commit changed product copy
+        run: |
+          if git diff --quiet -- README.md README.en.md docs/registry-stats.json; then
+            echo "Registry product copy is already current"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md README.en.md docs/registry-stats.json
+          git commit -m "docs: sync Registry connector counts [skip ci]"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+### Documentation
+
+- 产品介绍同步为公共 Registry 78 条、去重后市场 82 张卡片；新增 Registry/市场实时数量徽标。
+- 新增每小时 Registry 统计同步工作流，以 `catalog-stats.json` 为权威来源更新中英文 README 与本地快照，避免后续上架造成宣传数量过期。
+
 ## [0.2.20] - 2026-08-25
 
 ### Changed

--- a/README.en.md
+++ b/README.en.md
@@ -13,6 +13,8 @@ Browse and install MCP connectors from different providers in DeepSeek Harness D
 [![CI](https://github.com/duhu2000/dsh-mcp-connector/actions/workflows/ci.yml/badge.svg)](https://github.com/duhu2000/dsh-mcp-connector/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/dsh-mcp-connector.svg)](https://www.npmjs.com/package/dsh-mcp-connector)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Registry connectors](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fduhu2000%2Fdsh-mcp-connector-registry%2Fmain%2Fcatalog-stats.json&query=%24.registryCount&label=Registry%20connectors&color=5865f2)](https://github.com/duhu2000/dsh-mcp-connector-registry/blob/main/catalog-stats.json)
+[![Marketplace cards](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fduhu2000%2Fdsh-mcp-connector-registry%2Fmain%2Fcatalog-stats.json&query=%24.marketCount&label=Marketplace%20cards&color=16a34a)](https://github.com/duhu2000/dsh-mcp-connector-registry/blob/main/catalog-stats.json)
 
 ## Features
 
@@ -28,7 +30,9 @@ Browse and install MCP connectors from different providers in DeepSeek Harness D
 - A standalone remote Registry, allowing new marketplace cards to appear after refresh without publishing a new npm version.
 - Explicit, non-destructive migration of authorization from the two earlier Qichacha OAuth plugins.
 
-As of August 24, 2026, the public Registry publishes 61 connector descriptors. After merging and deduplicating them with the four bundled Qichacha cards, the Marketplace exposes 65 cards across nine business categories. Recommendations remain limited to the four Qichacha cards, PKULaw, and Wind, for six featured cards in total. The Registry can evolve independently, so the badge shown after a client refresh is the authoritative current count.
+<!-- catalog-stats:start -->
+As of 2026-08-25, the public Registry publishes 78 connector descriptors. After merging and deduplicating them with the 4 bundled Qichacha cards, the Marketplace exposes 82 cards across 9 business categories. Recommendations remain limited to the four Qichacha cards, PKULaw, and Wind, for 6 featured cards in total. The Registry evolves independently; the badge shown after a client refresh and the live badges above are the authoritative current counts.
+<!-- catalog-stats:end -->
 
 ## Interface and demo
 
@@ -104,6 +108,8 @@ npm run dev:ui
 ```
 
 `npm run check` performs syntax checks, automated tests, and an npm package allowlist/sensitive-content audit. `npm run market:check` tracks the external DSH marketplace PR and live directory. Tags matching `v*` trigger GitHub Actions; the tag must match `package.json`. npm releases use Trusted Publishing through GitHub OIDC and do not require a long-lived `NPM_TOKEN`.
+
+Every Registry merge regenerates `catalog-stats.json`; an hourly workflow in this repository synchronizes the Chinese and English product copy plus a local stats snapshot. The static npm README updates with package releases, while the live badges above read the Registry directly and therefore stay current without another npm release.
 
 The current public version is [`dsh-mcp-connector@0.2.20`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.20](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.20).
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 [![CI](https://github.com/duhu2000/dsh-mcp-connector/actions/workflows/ci.yml/badge.svg)](https://github.com/duhu2000/dsh-mcp-connector/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/dsh-mcp-connector.svg)](https://www.npmjs.com/package/dsh-mcp-connector)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Registry connectors](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fduhu2000%2Fdsh-mcp-connector-registry%2Fmain%2Fcatalog-stats.json&query=%24.registryCount&label=Registry%20connectors&color=5865f2)](https://github.com/duhu2000/dsh-mcp-connector-registry/blob/main/catalog-stats.json)
+[![Marketplace cards](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fduhu2000%2Fdsh-mcp-connector-registry%2Fmain%2Fcatalog-stats.json&query=%24.marketCount&label=Marketplace%20cards&color=16a34a)](https://github.com/duhu2000/dsh-mcp-connector-registry/blob/main/catalog-stats.json)
 
 ## 功能
 
@@ -30,7 +32,9 @@
 - 平滑迁移：显式扫描并复制两个旧企查查 OAuth 插件授权；不删除原插件或原凭据。
 - 对话工具：`mcp_connector_catalog`、`connect`、`configure`、`import_json`、`install_from_url`、`status`、`health_check`、`set_enabled`、`disconnect`、`refresh_catalog`、`publish`、`tools_list`。
 
-截至 2026-08-24，公共 Registry 已发布 61 条连接器描述；与随包的 4 张企查查卡片合并去重后，市场页可浏览 65 张卡片，覆盖企业数据、金融投资、法律合规、开发工具、办公协作、调研分析、设计创意、效率工具和其他 9 类。推荐位严格保留 4 张企查查卡片、北大法宝和 Wind，共 6 张；其他连接器按业务分类展示。Registry 可独立持续更新，实际数量以客户端刷新后的市场页签徽标为准。
+<!-- catalog-stats:start -->
+截至 2026-08-25，公共 Registry 已发布 78 条连接器描述；与随包的 4 张企查查卡片合并去重后，市场页可浏览 82 张卡片，覆盖企业数据、金融投资、法律合规、开发工具、办公协作、调研分析、设计创意、效率工具、其他 9 类。推荐位严格保留 4 张企查查卡片、北大法宝和 Wind，共 6 张；其他连接器按业务分类展示。Registry 可独立持续更新，实际数量以客户端刷新后的市场页签徽标和上方实时统计徽标为准。
+<!-- catalog-stats:end -->
 
 ## 界面与演示
 
@@ -99,6 +103,8 @@ npm run dev:ui
 ```
 
 `check` 执行语法检查、自动测试和 npm 发布包白名单校验；`market:check` 检查外部 DSH 市场 PR 与线上目录；`dev:ui` 启动不含真实凭据的本地 mock 市场。CI 使用 `--legacy-peer-deps` 安装显式测试依赖，DSH 运行期 peer 仍由 Host 提供。`v*` Tag 会触发 GitHub Actions；Tag 必须与 `package.json` 版本一致。Release 通过 npm Trusted Publishing (GitHub OIDC) 发布，不依赖长期 `NPM_TOKEN`。
+
+公共 Registry 每次合并后会生成 `catalog-stats.json`；本仓库的定时工作流每小时同步中英文介绍和统计快照。npm 页面中的静态正文随版本发布更新，上方动态统计徽标则直接读取 Registry，可在不发布新 npm 版本时保持实时数量一致。
 
 当前公开版本为 [`dsh-mcp-connector@0.2.20`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.20](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.20)。
 

--- a/docs/registry-stats.json
+++ b/docs/registry-stats.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "registryCount": 78,
+  "bundledUniqueCount": 4,
+  "marketCount": 82,
+  "featuredCount": 6,
+  "categoryCount": 9,
+  "categoryNames": [
+    "企业数据",
+    "金融投资",
+    "法律合规",
+    "开发工具",
+    "办公协作",
+    "调研分析",
+    "设计创意",
+    "效率工具",
+    "其他"
+  ],
+  "updatedOn": "2026-08-25"
+}

--- a/package.json
+++ b/package.json
@@ -33,11 +33,12 @@
   ],
   "scripts": {
     "test": "node --test",
-    "lint": "node --check lib/index.js && node --check lib/web.js && node --check lib/client.js && node --check lib/schema.js && node --check lib/catalog.js && node --check lib/prompts.js && node --check lib/probe.js && node --check lib/mcp-validation.js && node --check lib/mcp-http.js && node --check lib/migration.js && node --check lib/stores.js && node --check lib/oauth.js && node --check lib/callback-server.js && node --check lib/mcp-provision.js && node --check lib/util.js && node --check lib/constants.js && node --check lib/tools.js && node --check lib/connectors/oauth-connector.js && node --check lib/connectors/manual-connector.js && node --check lib/connectors/json-connector.js && node --check scripts/probe-connector.mjs && node --check scripts/build-registry.mjs && node --check scripts/ui-harness.mjs && node --check scripts/check-market-registration.mjs",
+    "lint": "node --check lib/index.js && node --check lib/web.js && node --check lib/client.js && node --check lib/schema.js && node --check lib/catalog.js && node --check lib/prompts.js && node --check lib/probe.js && node --check lib/mcp-validation.js && node --check lib/mcp-http.js && node --check lib/migration.js && node --check lib/stores.js && node --check lib/oauth.js && node --check lib/callback-server.js && node --check lib/mcp-provision.js && node --check lib/util.js && node --check lib/constants.js && node --check lib/tools.js && node --check lib/connectors/oauth-connector.js && node --check lib/connectors/manual-connector.js && node --check lib/connectors/json-connector.js && node --check scripts/probe-connector.mjs && node --check scripts/build-registry.mjs && node --check scripts/ui-harness.mjs && node --check scripts/check-market-registration.mjs && node --check scripts/sync-registry-stats.mjs",
     "registry:build": "node scripts/build-registry.mjs",
     "registry:validate": "node scripts/probe-connector.mjs catalog/catalog.json --validate-only",
     "dev:ui": "node scripts/ui-harness.mjs",
     "market:check": "node scripts/check-market-registration.mjs",
+    "registry:stats:sync": "node scripts/sync-registry-stats.mjs",
     "verify-pack": "node scripts/verify-pack.mjs",
     "check": "npm run lint && npm test && npm run verify-pack",
     "prepublishOnly": "npm run check"

--- a/scripts/sync-registry-stats.mjs
+++ b/scripts/sync-registry-stats.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const DEFAULT_STATS_URL =
+  'https://raw.githubusercontent.com/duhu2000/dsh-mcp-connector-registry/main/catalog-stats.json';
+export const STATS_START = '<!-- catalog-stats:start -->';
+export const STATS_END = '<!-- catalog-stats:end -->';
+
+function positiveInteger(value, name) {
+  if (!Number.isSafeInteger(value) || value <= 0 || value > 100_000) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+export function normalizeStats(value) {
+  if (!value || Array.isArray(value) || value.schemaVersion !== 1) {
+    throw new Error('registry stats must use schemaVersion 1');
+  }
+  const registryCount = positiveInteger(value.registryCount, 'registryCount');
+  const bundledUniqueCount = positiveInteger(value.bundledUniqueCount, 'bundledUniqueCount');
+  const marketCount = positiveInteger(value.marketCount, 'marketCount');
+  const featuredCount = positiveInteger(value.featuredCount, 'featuredCount');
+  const categoryCount = positiveInteger(value.categoryCount, 'categoryCount');
+  if (marketCount !== registryCount + bundledUniqueCount) {
+    throw new Error('marketCount must equal registryCount + bundledUniqueCount');
+  }
+  if (featuredCount > marketCount) throw new Error('featuredCount must not exceed marketCount');
+  if (!Array.isArray(value.categoryNames) || value.categoryNames.length !== categoryCount) {
+    throw new Error('categoryNames length must equal categoryCount');
+  }
+  const categoryNames = value.categoryNames.map((name) => {
+    if (typeof name !== 'string' || !/^[\p{L}\p{N} .&+/-]{1,40}$/u.test(name)) {
+      throw new Error('categoryNames contains an unsafe value');
+    }
+    return name;
+  });
+  if (new Set(categoryNames).size !== categoryNames.length) throw new Error('categoryNames must be unique');
+  if (typeof value.updatedOn !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value.updatedOn)) {
+    throw new Error('updatedOn must use YYYY-MM-DD');
+  }
+  return {
+    schemaVersion: 1,
+    registryCount,
+    bundledUniqueCount,
+    marketCount,
+    featuredCount,
+    categoryCount,
+    categoryNames,
+    updatedOn: value.updatedOn,
+  };
+}
+
+export function renderChineseStats(stats) {
+  return `${STATS_START}\n截至 ${stats.updatedOn}，公共 Registry 已发布 ${stats.registryCount} 条连接器描述；与随包的 ${stats.bundledUniqueCount} 张企查查卡片合并去重后，市场页可浏览 ${stats.marketCount} 张卡片，覆盖${stats.categoryNames.join('、')} ${stats.categoryCount} 类。推荐位严格保留 4 张企查查卡片、北大法宝和 Wind，共 ${stats.featuredCount} 张；其他连接器按业务分类展示。Registry 可独立持续更新，实际数量以客户端刷新后的市场页签徽标和上方实时统计徽标为准。\n${STATS_END}`;
+}
+
+export function renderEnglishStats(stats) {
+  return `${STATS_START}\nAs of ${stats.updatedOn}, the public Registry publishes ${stats.registryCount} connector descriptors. After merging and deduplicating them with the ${stats.bundledUniqueCount} bundled Qichacha cards, the Marketplace exposes ${stats.marketCount} cards across ${stats.categoryCount} business categories. Recommendations remain limited to the four Qichacha cards, PKULaw, and Wind, for ${stats.featuredCount} featured cards in total. The Registry evolves independently; the badge shown after a client refresh and the live badges above are the authoritative current counts.\n${STATS_END}`;
+}
+
+export function replaceStatsBlock(text, replacement) {
+  const start = text.indexOf(STATS_START);
+  const end = text.indexOf(STATS_END);
+  if (start === -1 || end === -1 || end < start) throw new Error('README catalog stats markers are missing or invalid');
+  return `${text.slice(0, start)}${replacement}${text.slice(end + STATS_END.length)}`;
+}
+
+async function fetchStats(url, { fetchImpl = fetch, attempts = 3, timeoutMs = 15_000 } = {}) {
+  const endpoint = new URL(url);
+  if (endpoint.protocol !== 'https:' || endpoint.hostname !== 'raw.githubusercontent.com') {
+    throw new Error('stats URL must use https://raw.githubusercontent.com');
+  }
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(new Error('request timeout')), timeoutMs);
+    try {
+      const response = await fetchImpl(endpoint, {
+        headers: { Accept: 'application/json', 'User-Agent': 'dsh-mcp-connector-stats-sync' },
+        signal: controller.signal,
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return normalizeStats(await response.json());
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) await new Promise((resolveDelay) => setTimeout(resolveDelay, 1_000 * attempt));
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  throw new Error(`unable to fetch registry stats after ${attempts} attempts: ${lastError?.message ?? lastError}`);
+}
+
+export async function syncRegistryStats({
+  sourcePath,
+  statsUrl = DEFAULT_STATS_URL,
+  chineseReadmePath = 'README.md',
+  englishReadmePath = 'README.en.md',
+  snapshotPath = 'docs/registry-stats.json',
+  fetchImpl,
+} = {}) {
+  const stats = sourcePath
+    ? normalizeStats(JSON.parse(await readFile(resolve(sourcePath), 'utf8')))
+    : await fetchStats(statsUrl, { fetchImpl });
+  const [chinese, english] = await Promise.all([
+    readFile(resolve(chineseReadmePath), 'utf8'),
+    readFile(resolve(englishReadmePath), 'utf8'),
+  ]);
+  await Promise.all([
+    writeFile(resolve(chineseReadmePath), replaceStatsBlock(chinese, renderChineseStats(stats))),
+    writeFile(resolve(englishReadmePath), replaceStatsBlock(english, renderEnglishStats(stats))),
+    writeFile(resolve(snapshotPath), `${JSON.stringify(stats, null, 2)}\n`),
+  ]);
+  return stats;
+}
+
+function sourceArgument(argv) {
+  const index = argv.indexOf('--source');
+  if (index === -1) return undefined;
+  if (!argv[index + 1]) throw new Error('--source requires a local JSON path');
+  return argv[index + 1];
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  syncRegistryStats({ sourcePath: sourceArgument(process.argv.slice(2)) }).then((stats) => {
+    console.log(`registry-stats: synced ${stats.registryCount} registry / ${stats.marketCount} market connectors`);
+  }).catch((error) => {
+    console.error(`registry-stats: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/test/registry-stats-sync.test.mjs
+++ b/test/registry-stats-sync.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import {
+  normalizeStats,
+  renderChineseStats,
+  syncRegistryStats,
+} from '../scripts/sync-registry-stats.mjs';
+
+const stats = {
+  schemaVersion: 1,
+  registryCount: 78,
+  bundledUniqueCount: 4,
+  marketCount: 82,
+  featuredCount: 6,
+  categoryCount: 9,
+  categoryNames: ['企业数据', '金融投资', '法律合规', '开发工具', '办公协作', '调研分析', '设计创意', '效率工具', '其他'],
+  updatedOn: '2026-08-25',
+};
+
+test('validates count relationships and safe category names', () => {
+  assert.deepEqual(normalizeStats(stats), stats);
+  assert.throws(() => normalizeStats({ ...stats, marketCount: 81 }), /marketCount must equal/);
+  assert.throws(() => normalizeStats({ ...stats, categoryNames: [...stats.categoryNames.slice(0, 8), '[bad]'] }), /unsafe value/);
+  assert.match(renderChineseStats(stats), /78 条.*82 张.*9 类.*6 张/s);
+});
+
+test('syncs the Chinese and English generated blocks plus local snapshot', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'dsh-registry-stats-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const sourcePath = join(directory, 'source.json');
+  const chinesePath = join(directory, 'README.md');
+  const englishPath = join(directory, 'README.en.md');
+  const snapshotPath = join(directory, 'snapshot.json');
+  const marked = 'before\n<!-- catalog-stats:start -->\nstale\n<!-- catalog-stats:end -->\nafter\n';
+  await Promise.all([
+    writeFile(sourcePath, JSON.stringify(stats)),
+    writeFile(chinesePath, marked),
+    writeFile(englishPath, marked),
+  ]);
+
+  await syncRegistryStats({ sourcePath, chineseReadmePath: chinesePath, englishReadmePath: englishPath, snapshotPath });
+  const [chinese, english, snapshot] = await Promise.all([
+    readFile(chinesePath, 'utf8'), readFile(englishPath, 'utf8'), readFile(snapshotPath, 'utf8'),
+  ]);
+  assert.match(chinese, /Registry 已发布 78 条.*82 张/s);
+  assert.match(english, /publishes 78 connector descriptors.*exposes 82 cards/s);
+  assert.deepEqual(JSON.parse(snapshot), stats);
+});


### PR DESCRIPTION
## Summary

- update the Chinese and English product introductions from 61/65 to 78/82 connectors
- add live Registry and Marketplace count badges for GitHub and npm README rendering
- add a validated local stats snapshot and synchronization script
- run an hourly GitHub workflow that updates both README count blocks when Registry stats change
- document npm's static README release boundary

## Source of truth

Consumes `catalog-stats.json` introduced by duhu2000/dsh-mcp-connector-registry#10:

- Registry descriptors: 78
- bundled unique Qichacha cards: 4
- merged marketplace cards: 82
- featured cards: 6
- categories: 9

Merge the Registry PR first so the public stats endpoint exists before this scheduled workflow becomes active.

## Verification

- [x] 100/100 plugin tests
- [x] synchronization is idempotent against the checked-in snapshot
- [x] lint and workflow YAML parse
- [x] npm dry-run allowlist and sensitive-content audit: 47 files
- [x] diff format and secret-pattern scan

## npm behavior

This PR does not publish a package. The current npm page keeps the README bundled in v0.2.20 until the next patch release. After that release, the dynamic badges will stay current without republishing for every Registry count change; static prose updates on GitHub hourly and enters npm with normal releases.