### PR TITLE
release: prepare v0.2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,16 @@
 
 ## [Unreleased]
 
+## [0.2.21] - 2026-08-25
+
 ### Documentation
 
 - 产品介绍同步为公共 Registry 78 条、去重后市场 82 张卡片；新增 Registry/市场实时数量徽标。
 - 新增每小时 Registry 统计同步工作流，以 `catalog-stats.json` 为权威来源更新中英文 README 与本地快照，避免后续上架造成宣传数量过期。
+
+### Verification
+
+- 插件 100 项自动测试、lint、Registry 统计同步幂等性、npm 发布文件白名单/敏感内容扫描和 `git diff --check` 通过。
 
 ## [0.2.20] - 2026-08-25
 

--- a/README.en.md
+++ b/README.en.md
@@ -111,7 +111,7 @@ npm run dev:ui
 
 Every Registry merge regenerates `catalog-stats.json`; an hourly workflow in this repository synchronizes the Chinese and English product copy plus a local stats snapshot. The static npm README updates with package releases, while the live badges above read the Registry directly and therefore stay current without another npm release.
 
-The current public version is [`dsh-mcp-connector@0.2.20`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.20](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.20).
+The current public version is [`dsh-mcp-connector@0.2.21`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.21](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.21).
 
 See [CHANGELOG.md](CHANGELOG.md) for version history and [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md) for the Desktop release checklist.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ npm run dev:ui
 
 公共 Registry 每次合并后会生成 `catalog-stats.json`；本仓库的定时工作流每小时同步中英文介绍和统计快照。npm 页面中的静态正文随版本发布更新，上方动态统计徽标则直接读取 Registry，可在不发布新 npm 版本时保持实时数量一致。
 
-当前公开版本为 [`dsh-mcp-connector@0.2.20`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.20](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.20)。
+当前公开版本为 [`dsh-mcp-connector@0.2.21`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.21](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.21)。
 
 版本能力与变更记录见 [CHANGELOG.md](CHANGELOG.md)。
 Desktop 发版回归见 [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mcp-connector",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "General-purpose MCP connector, connection manager, plugin extension, and integration marketplace for DeepSeek Harness, initiated and maintained by Qichacha/QCC.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## Release

Prepare `dsh-mcp-connector@0.2.21` so the npm package page receives the current 78/82 connector introduction and live count badges from #9.

## Changes

- bump package version from 0.2.20 to 0.2.21
- finalize the 0.2.21 changelog section
- update Chinese and English version/Release links
- no runtime connector behavior changes

## Verification

- [x] 100/100 automated tests
- [x] lint and Registry stats synchronization checks
- [x] npm dry-run allowlist and sensitive-content audit: 47 files
- [x] `git diff --check`

After merge, tag `v0.2.21` will trigger Trusted Publishing to npm and create the GitHub Release.