### PR TITLE
release: prepare v0.2.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [0.2.22] - 2026-08-26
+
 ### Fixed
 
 - 首次连接改为等待 `dsh-mcp-client` 完成 MCP `initialize` 与首次 `tools/list`；启动失败或超时不再提前保存、增加已安装数量或显示“已连接”。
@@ -370,7 +372,9 @@
 - 外部 URL 与导入 Header 执行安全校验。
 - iframe 消息校验同源和消息来源。
 
-[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.20...HEAD
+[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.22...HEAD
+[0.2.22]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.21...v0.2.22
+[0.2.21]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.20...v0.2.21
 [0.2.20]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.19...v0.2.20
 [0.2.19]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.18...v0.2.19
 [0.2.18]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.17...v0.2.18

--- a/README.en.md
+++ b/README.en.md
@@ -111,7 +111,7 @@ npm run dev:ui
 
 Every Registry merge regenerates `catalog-stats.json`; an hourly workflow in this repository synchronizes the Chinese and English product copy plus a local stats snapshot. The static npm README updates with package releases, while the live badges above read the Registry directly and therefore stay current without another npm release.
 
-The current public version is [`dsh-mcp-connector@0.2.21`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.21](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.21).
+The current public version is [`dsh-mcp-connector@0.2.22`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.22](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.22).
 
 See [CHANGELOG.md](CHANGELOG.md) for version history and [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md) for the Desktop release checklist.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ npm run dev:ui
 
 公共 Registry 每次合并后会生成 `catalog-stats.json`；本仓库的定时工作流每小时同步中英文介绍和统计快照。npm 页面中的静态正文随版本发布更新，上方动态统计徽标则直接读取 Registry，可在不发布新 npm 版本时保持实时数量一致。
 
-当前公开版本为 [`dsh-mcp-connector@0.2.21`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.21](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.21)。
+当前公开版本为 [`dsh-mcp-connector@0.2.22`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.22](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.22)。
 
 版本能力与变更记录见 [CHANGELOG.md](CHANGELOG.md)。
 Desktop 发版回归见 [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mcp-connector",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "description": "General-purpose MCP connector, connection manager, plugin extension, and integration marketplace for DeepSeek Harness, initiated and maintained by Qichacha/QCC.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 发布内容

- 将包版本升级至 `0.2.22`
- 发布连接就绪校验、失败回滚与有限超时修复
- 更新中英文 README 公开版本链接
- 整理 CHANGELOG 版本区间与 `0.2.21` / `0.2.22` 比较链接

## 关联修复

- #7 手动 HTTP 连接未完成 initialize 校验即被保存
- #8 AKShare 显示已连接但工具列表持续加载且无超时提示

## 发布验证

- `npm run check`：106/106 tests passed
- npm 发布包：47 个文件，白名单与敏感信息扫描通过
- `npm pack`：生成 `dsh-mcp-connector-0.2.22.tgz`
- 从 tarball 执行全新 `npm install` 冒烟测试通过

合并后将创建并推送 `v0.2.22` Tag，由 Trusted Publishing 工作流发布 npm 并创建 GitHub Release。
