### PR TITLE
release: prepare v0.2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [0.2.24] - 2026-08-27
+
 ### Added
 
 - MCP连接器标题显示当前插件版本，并由服务端缓存检查 npm `latest` 与 GitHub Release；发现新版本时引导用户前往 DSH 插件市场安全更新。
@@ -11,6 +13,10 @@
 ### Changed
 
 - 市场页原“刷新”按钮改为“刷新连接器目录”，明确该操作仅更新 Registry 卡片，不会升级插件本身。
+
+### Verification
+
+- 123 项自动测试、lint、npm 发布包白名单/敏感内容扫描和 npm/GitHub 真实版本源验收通过。
 
 ## [0.2.23] - 2026-08-26
 
@@ -393,7 +399,8 @@
 - 外部 URL 与导入 Header 执行安全校验。
 - iframe 消息校验同源和消息来源。
 
-[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.23...HEAD
+[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.24...HEAD
+[0.2.24]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.23...v0.2.24
 [0.2.23]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.22...v0.2.23
 [0.2.22]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.21...v0.2.22
 [0.2.21]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.20...v0.2.21

--- a/README.en.md
+++ b/README.en.md
@@ -112,7 +112,7 @@ npm run dev:ui
 
 Every Registry merge regenerates `catalog-stats.json`; an hourly workflow in this repository synchronizes the Chinese and English product copy plus a local stats snapshot. The static npm README updates with package releases, while the live badges above read the Registry directly and therefore stay current without another npm release.
 
-The current public version is [`dsh-mcp-connector@0.2.23`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.23](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.23).
+The current public version is [`dsh-mcp-connector@0.2.24`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.24](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.24).
 
 See [CHANGELOG.md](CHANGELOG.md) for version history and [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md) for the Desktop release checklist.
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ npm run dev:ui
 
 公共 Registry 每次合并后会生成 `catalog-stats.json`；本仓库的定时工作流每小时同步中英文介绍和统计快照。npm 页面中的静态正文随版本发布更新，上方动态统计徽标则直接读取 Registry，可在不发布新 npm 版本时保持实时数量一致。
 
-当前公开版本为 [`dsh-mcp-connector@0.2.23`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.23](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.23)。
+当前公开版本为 [`dsh-mcp-connector@0.2.24`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.24](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.24)。
 
 版本能力与变更记录见 [CHANGELOG.md](CHANGELOG.md)。
 Desktop 发版回归见 [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mcp-connector",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "General-purpose MCP connector, connection manager, plugin extension, and integration marketplace for DeepSeek Harness, initiated and maintained by Qichacha/QCC.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## Release v0.2.24

### Included

- display the installed MCP Connector plugin version beside the market title
- check npm latest and GitHub Releases through a cached server-side service
- route available upgrades through the DSH plugin marketplace
- rename the catalog action to “刷新连接器目录” so it is distinct from plugin upgrades
- update Chinese/English documentation and release notes

### Verification

- `npm run check`
- 123/123 automated tests passed
- lint passed
- npm package allowlist and sensitive-content scan passed
- npm Registry confirmed `latest=0.2.23` before release

After merge, tag `v0.2.24` will trigger Trusted Publishing to npm and create the GitHub Release.
