### PR TITLE
fix: harden plugin upgrades and OAuth recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- 升级启动时自动发现并归并历史版本为同 issuer 卡片保存的多份 OAuth Grant；归并前先验证过期 Grant 是否仍可刷新，避免用较新但已失效的凭据覆盖可恢复授权。
+- 多个 DSH 进程并发刷新同一组轮换式 Refresh Token 时，收到 `invalid_grant` 后会短暂重读本机持久化 Grant；发现其他进程已保存新 Token 时自动采用并重试，不再误报“需重新授权”。
+- 页面不再盲信 Update Provider 的 `succeeded`；独立校验更新前、预期与实际版本，检测降级、解析版本偏差或无效结果时拒绝重启，并在 Provider 保留恢复点时自动回滚。
+
+### Verification
+
+- 129 项自动测试、lint、npm 发布包白名单与敏感内容扫描通过；新增历史 Grant 安全归并、失效候选回退、跨进程 Token 轮换恢复和 Provider 版本完整性回归测试。
+
 ## [0.2.25] - 2026-08-27
 
 ### Added

--- a/docs/PLUGIN-UPDATE.md
+++ b/docs/PLUGIN-UPDATE.md
@@ -21,10 +21,11 @@ DSH Market 适配器从 `GET /dsh-market/api/v1/capabilities` 开始，要求 `s
 1. 插件自己的服务端缓存检查 npm `latest` 与 GitHub Release，只在 npm 已有可安装新版本时提示升级。
 2. 选中的 Provider 再检查本 profile 中 `dsh-mcp-connector` 的实际安装版本和目标版本。
 3. 用户点击“一键更新”后，Provider 立即返回 `operationId`；页面通过适配器轮询任务状态，展示排队、解析、下载和安装进度。
-4. 成功后按 Provider 返回的激活结论展示“刷新生效”或重启提示。Web 且 Provider 明确允许进程重启时才展示“立即重启”；Desktop 等由外壳管理生命周期的宿主只提示用户重启，不自行杀进程。
-5. Provider 保留恢复点时展示“回滚”。回滚仍由 Provider 执行，MCP连接器不直接修改 profile、lockfile 或 `node_modules`。
+4. Provider 报告成功后，页面仍会独立校验 `beforeVersion`、点击时的预期版本与 `installedVersion`。降级、目标不一致或无效结果会被拒绝；Provider 保留恢复点时自动回滚，不向用户展示重启。
+5. 完整性校验通过后，按 Provider 返回的激活结论展示“刷新生效”或重启提示。Web 且 Provider 明确允许进程重启时才展示“立即重启”；Desktop 等由外壳管理生命周期的宿主只提示用户重启，不自行杀进程。
+6. Provider 保留恢复点时展示“回滚”。回滚仍由 Provider 执行，MCP连接器不直接修改 profile、lockfile 或 `node_modules`。
 
-失败结果使用稳定代码区分正在运行的 Agent、其他安装任务占用、镜像同步、版本未变化、超时和权限拒绝。可重试失败保留重试操作；Registry 刚发布但镜像仍未同步时，用户可在看到明确提示后选择强制重试。
+失败结果使用稳定代码区分正在运行的 Agent、其他安装任务占用、镜像同步、版本未变化、超时和权限拒绝，以及 `DOWNGRADE_DETECTED`、`RESOLVED_VERSION_MISMATCH`、`INVALID_UPDATE_RESULT` 三类完整性故障。可重试失败保留重试操作；Registry 刚发布但镜像仍未同步时，用户可在看到明确提示后选择强制重试。
 
 ## 安全边界
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -75,7 +75,7 @@ stdio 市场卡片也可能显示一个或多个凭据字段，例如 API Token�
 
 OAuth 一键连接要求服务商支持标准 OAuth 2.1/PKCE 和公开元数据发现。动态客户端注册既支持无需客户端密钥的 `none`，也支持服务商签发密钥的 `client_secret_post` 与 `client_secret_basic`。客户端密钥仅与 OAuth Grant 一同保存在 DSH 本机，用于换取、刷新和撤销 Token；插件不会要求用户把 OAuth Token 或客户端密钥复制到聊天中。
 
-当市场描述声明 `grantSharing: "issuer"` 时，同一账号下相同 issuer、scope 和客户端鉴权方式的卡片共享一组 Grant。首次授权仍只启用用户点击的卡片；之后连接同组卡片会直接复用现有授权，不再重复打开 OAuth 页面。网络、OAuth 元数据发现或服务端 5xx 等暂时故障只进入“自动重试中”，明确收到 Refresh Token/客户端失效错误时才进入“需重新授权”。
+当市场描述声明 `grantSharing: "issuer"` 时，同一账号下相同 issuer、scope 和客户端鉴权方式的卡片共享一组 Grant。首次授权仍只启用用户点击的卡片；之后连接同组卡片会直接复用现有授权，不再重复打开 OAuth 页面。升级时会验证并自动归并旧版本留下的同 issuer 多份 Grant；多个 DSH 进程并发轮换 Refresh Token 时也会重读较新的本机持久化凭据后自动恢复。网络、OAuth 元数据发现或服务端 5xx 等暂时故障只进入“自动重试中”，确认本机也没有其他进程保存的新 Token，且明确收到 Refresh Token/客户端失效错误时，才进入“需重新授权”。
 
 ## 5. 查看详情、Prompt 与工具
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -363,11 +363,79 @@ window.__ModuleLoader__.load({
 				OPERATION_BUSY: "插件市场正在处理其他任务",
 				RELEASE_TOO_FRESH: "新版本仍在镜像同步",
 				VERSION_UNCHANGED: "下载后版本未变化",
+				DOWNGRADE_DETECTED: "已阻止版本降级",
+				RESOLVED_VERSION_MISMATCH: "下载版本与预期不一致",
+				INVALID_UPDATE_RESULT: "更新服务未返回有效版本",
 				UPDATE_TIMEOUT: "更新超时",
 				UPDATE_FORBIDDEN: "更新请求被拒绝",
 				UPDATE_REJECTED: "无法执行本次更新"
 			};
 			return labels[failure?.code] ?? failure?.message ?? "更新失败";
+		}
+
+		function parseClientVersion(value) {
+			if (typeof value !== "string") return null;
+			const normalized = value.trim().replace(/^v/i, "");
+			if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(normalized)) return null;
+			const [withoutBuild] = normalized.split("+");
+			const [core, prerelease] = withoutBuild.split("-", 2);
+			return { normalized, core: core.split(".").map(Number), prerelease: prerelease?.split(".") ?? [] };
+		}
+
+		function compareClientVersions(left, right) {
+			const a = parseClientVersion(left);
+			const b = parseClientVersion(right);
+			if (a === null || b === null) return null;
+			for (let index = 0; index < 3; index += 1) {
+				if (a.core[index] !== b.core[index]) return a.core[index] - b.core[index];
+			}
+			if (a.prerelease.length === 0 && b.prerelease.length > 0) return 1;
+			if (a.prerelease.length > 0 && b.prerelease.length === 0) return -1;
+			const length = Math.max(a.prerelease.length, b.prerelease.length);
+			for (let index = 0; index < length; index += 1) {
+				const aPart = a.prerelease[index];
+				const bPart = b.prerelease[index];
+				if (aPart === void 0) return -1;
+				if (bPart === void 0) return 1;
+				if (aPart === bPart) continue;
+				const aNumeric = /^\d+$/.test(aPart);
+				const bNumeric = /^\d+$/.test(bPart);
+				if (aNumeric && bNumeric) return Number(aPart) - Number(bPart);
+				if (aNumeric) return -1;
+				if (bNumeric) return 1;
+				return aPart.localeCompare(bPart);
+			}
+			return 0;
+		}
+
+		/** Independently verify a provider's terminal success before asking the user to restart. */
+		function completedUpdateIntegrityFailure(operation, expectedVersion) {
+			if (operation?.state !== "succeeded") return null;
+			const installed = parseClientVersion(operation.installedVersion);
+			if (installed === null) {
+				return {
+					code: "INVALID_UPDATE_RESULT",
+					message: "更新服务报告成功，但未返回有效的已安装版本",
+					retryable: false
+				};
+			}
+			const before = parseClientVersion(operation.beforeVersion);
+			if (before !== null && compareClientVersions(installed.normalized, before.normalized) < 0) {
+				return {
+					code: "DOWNGRADE_DETECTED",
+					message: `更新服务将插件从 v${before.normalized} 降级到 v${installed.normalized}`,
+					retryable: false
+				};
+			}
+			const expected = parseClientVersion(expectedVersion);
+			if (expected !== null && compareClientVersions(installed.normalized, expected.normalized) !== 0) {
+				return {
+					code: "RESOLVED_VERSION_MISMATCH",
+					message: `预期安装 v${expected.normalized}，更新服务实际安装了 v${installed.normalized}`,
+					retryable: true
+				};
+			}
+			return null;
 		}
 
 		/**
@@ -451,6 +519,7 @@ window.__ModuleLoader__.load({
 			const [updateProviderState, setUpdateProviderState] = (0, react.useState)("checking");
 			const [updateProviderSelection, setUpdateProviderSelection] = (0, react.useState)(null);
 			const [providerUpdateCheck, setProviderUpdateCheck] = (0, react.useState)(null);
+			const [expectedUpdateVersion, setExpectedUpdateVersion] = (0, react.useState)(null);
 			const [updateOperation, setUpdateOperation] = (0, react.useState)(null);
 			const [updateError, setUpdateError] = (0, react.useState)(null);
 			const [updateStarting, setUpdateStarting] = (0, react.useState)(false);
@@ -564,6 +633,34 @@ window.__ModuleLoader__.load({
 					provider.operation(capabilities, operationId).then((operation) => {
 						if (disposed) return;
 						setUpdateError(null);
+						const integrityFailure = completedUpdateIntegrityFailure(operation, expectedUpdateVersion);
+						if (integrityFailure !== null) {
+							const failedOperation = { ...operation, state: "failed", failure: integrityFailure };
+							setUpdateOperation(failedOperation);
+							const canRollback = capabilities.features?.rollback === true
+								&& operation.outcome?.rollback?.available === true
+								&& capabilities.endpoints.rollback !== null;
+							if (!canRollback) return;
+							setRollbackRunning(true);
+							provider.rollback(capabilities, operationId).then((rolledBackOperation) => {
+								if (disposed) return;
+								setRollbackRunning(false);
+								setUpdateOperation({ ...rolledBackOperation, integrityFailure });
+							}, (error) => {
+								console.error("[mcp-connector] automatic rollback failed:", error);
+								if (disposed) return;
+								const detail = error instanceof Error ? error.message : String(error);
+								setRollbackRunning(false);
+								setUpdateOperation({
+									...failedOperation,
+									outcome: {
+										...failedOperation.outcome,
+										rollback: { available: true, state: "failed", detail }
+									}
+								});
+							});
+							return;
+						}
 						setUpdateOperation(operation);
 						if (["queued", "running"].includes(operation.state)) {
 							timer = window.setTimeout(poll, UPDATE_PROVIDER_OPERATION_POLL_MS);
@@ -584,7 +681,7 @@ window.__ModuleLoader__.load({
 					disposed = true;
 					window.clearTimeout(timer);
 				};
-			}, [open, updateOperation?.operationId, updateProviderSelection?.provider?.id]);
+			}, [open, updateOperation?.operationId, updateProviderSelection?.provider?.id, expectedUpdateVersion]);
 			(0, react.useEffect)(() => {
 				if (!open) return void 0;
 				closeRef.current?.focus?.();
@@ -600,6 +697,7 @@ window.__ModuleLoader__.load({
 				if (updateRunning || provider === void 0 || capabilities === void 0) return;
 				setUpdateError(null);
 				setUpdateStarting(true);
+				setExpectedUpdateVersion(providerUpdateCheck?.latestVersion ?? versionStatus?.latestVersion ?? null);
 				provider.start(capabilities, PLUGIN_PACKAGE_NAME, force).then((operation) => {
 					setUpdateStarting(false);
 					setUpdateOperation(operation);
@@ -687,6 +785,10 @@ window.__ModuleLoader__.load({
 								onClick: () => startUpdate(force),
 								children: force ? "强制重试" : "重试更新"
 							}),
+							rollbackRunning && /* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
+								className: "mcpConnectorUpdateStatus",
+								children: "检测到异常版本，正在自动回滚…"
+							}),
 							/* @__PURE__ */ (0, react_jsx_runtime.jsx)("button", {
 								type: "button",
 								className: "mcpConnectorUpdateButton mcpConnectorUpdateSecondary",
@@ -707,7 +809,7 @@ window.__ModuleLoader__.load({
 							/* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
 								className: "mcpConnectorUpdateStatus",
 								children: rolledBack
-									? "已回滚"
+									? updateOperation.integrityFailure === void 0 ? "已回滚" : "已阻止异常版本并回滚"
 									: `已安装 v${updateOperation.installedVersion ?? versionStatus?.latestVersion}`
 							}),
 							rollbackFailed && /* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {

--- a/lib/index.js
+++ b/lib/index.js
@@ -380,12 +380,41 @@ export async function apply(ctx, config) {
   }
 
   async function refreshGrantWithRecovery(grantKey, phase) {
+    const observed = state.grants.get(grantKey)?.grant;
     try {
       return await refreshGrant(grantKey);
     } catch (error) {
+      let finalError = error;
+      const initialFailure = classifyRefreshFailure(error);
+      // Refresh tokens are commonly rotated. If another DSH process refreshed
+      // the same persisted grant first, this process still holds the old token
+      // and receives invalid_grant. Re-read storage before declaring the user
+      // logged out; a newer token is authoritative and can be retried once.
+      if (config.persistSecrets && observed
+          && ['invalid_grant', 'invalid_token'].includes(initialFailure.code)) {
+        for (const delayMs of [0, 100, 250]) {
+          if (delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
+          const persisted = await grantStore.get(grantKey).catch(() => undefined);
+          const entry = state.grants.get(grantKey);
+          if (!entry || !persisted
+              || persisted.updatedAt <= observed.updatedAt
+              || persisted.refreshToken === observed.refreshToken) continue;
+          entry.grant = persisted;
+          entry.needsReauth = false;
+          entry.refreshFailureKind = null;
+          entry.lastRefreshError = null;
+          logger.info(`OAuth grant ${grantKey} adopted a newer persisted token after a concurrent rotation`);
+          try {
+            return await refreshGrant(grantKey);
+          } catch (retryError) {
+            finalError = retryError;
+          }
+          break;
+        }
+      }
       // 多个调用方可能等待同一个 refreshPromise；同一次失败只能记一次并调度一个重试。
-      if (!error.refreshFailure) error.refreshFailure = recordRefreshFailure(grantKey, error, phase);
-      throw error;
+      if (!finalError.refreshFailure) finalError.refreshFailure = recordRefreshFailure(grantKey, finalError, phase);
+      throw finalError;
     }
   }
 
@@ -856,6 +885,86 @@ export async function apply(ctx, config) {
       });
       throw error;
     }
+  }
+
+  /**
+   * v0.2.22 及更早版本会让四张企查查卡片分别保存动态客户端和 Grant。
+   * 新版升级时把同 issuer、同资源域且授权范围完整的历史记录归并为一组，
+   * 这样启动只刷新一个 refresh token，之后任意一张卡片重新授权也会修复整组。
+   */
+  async function consolidatePersistedSharedGrants() {
+    const groups = new Map();
+    for (const record of state.connections.values()) {
+      if (record.auth?.mode !== 'oauth' || !record.auth.grantKey) continue;
+      const connector = state.merged.find((item) => item.id === record.connectorId);
+      if (connector?.auth?.grantSharing !== 'issuer') continue;
+      const groupKey = oauthSharingKey(connector);
+      const group = groups.get(groupKey) ?? { records: [], grantKeys: new Set() };
+      group.records.push(record);
+      group.grantKeys.add(record.auth.grantKey);
+      groups.set(groupKey, group);
+    }
+
+    let consolidated = 0;
+    for (const group of groups.values()) {
+      if (group.grantKeys.size <= 1) continue;
+      const requiredResources = new Set(group.records.map((record) => record.url).filter(Boolean));
+      const candidates = [...group.grantKeys]
+        .map((key) => [key, state.grants.get(key)])
+        .filter(([, entry]) => entry
+          && [...requiredResources].every((resource) => entry.grant.authorizedResources.includes(resource)))
+        .sort((left, right) => (
+          (right[1].grant.updatedAt ?? 0) - (left[1].grant.updatedAt ?? 0)
+          || (right[1].grant.accessTokenExpiresAt ?? 0) - (left[1].grant.accessTokenExpiresAt ?? 0)
+        ));
+      if (candidates.length === 0) continue;
+
+      // Do not retire three recoverable historical grants in favour of a newer
+      // but already-revoked refresh token. Validate expired candidates in
+      // recency order and only consolidate after one grant is demonstrably
+      // usable. If none is usable, preserve every grant so one subsequent
+      // authorization can replace the group without destroying recovery data.
+      let winnerCandidate;
+      for (const candidate of candidates) {
+        const [candidateKey, candidateEntry] = candidate;
+        if (candidateEntry.needsReauth) continue;
+        if (candidateEntry.grant.accessTokenExpiresAt <= Date.now()) {
+          try {
+            await refreshGrantWithRecovery(candidateKey, 'startup-consolidation');
+          } catch {
+            continue;
+          }
+        }
+        winnerCandidate = candidate;
+        break;
+      }
+      if (winnerCandidate === undefined) {
+        logger.warn(`preserved ${group.grantKeys.size} historical issuer-shared OAuth grants because none could be refreshed`);
+        continue;
+      }
+
+      const [winnerKey, winnerEntry] = winnerCandidate;
+      const connectorIds = [...new Set([
+        ...(winnerEntry.grant.connectorIds ?? []),
+        ...group.records.map((record) => record.connectorId),
+      ])];
+      const winner = { ...winnerEntry.grant, connectorIds, updatedAt: Date.now() };
+      winnerEntry.grant = winner;
+      if (config.persistSecrets) await grantStore.put(winner);
+
+      for (const record of group.records) {
+        if (record.auth.grantKey === winnerKey) continue;
+        const next = { ...record, auth: { ...record.auth, grantKey: winnerKey }, updatedAt: Date.now() };
+        const persisted = config.persistSecrets ? await connectionStore.put(next) : next;
+        state.connections.set(record.key, persisted);
+      }
+      for (const losingKey of group.grantKeys) {
+        if (losingKey !== winnerKey) await retireGrantIfUnused(losingKey);
+      }
+      consolidated += group.grantKeys.size - 1;
+      logger.info(`consolidated ${group.grantKeys.size} issuer-shared OAuth grants into ${winnerKey}`);
+    }
+    return consolidated;
   }
 
   /* ───────────────────────── api 门面 ───────────────────────── */
@@ -1611,6 +1720,9 @@ export async function apply(ctx, config) {
       logger.warn(`skip invalid stored grant "${key}": ${error.message}`);
     }
   }
+
+  const consolidatedGrantCount = await consolidatePersistedSharedGrants();
+  if (consolidatedGrantCount > 0) logger.info(`consolidated ${consolidatedGrantCount} historical OAuth grant(s) during startup`);
 
   const prunedGrantCount = await pruneOrphanGrants();
   if (prunedGrantCount > 0) logger.info(`removed ${prunedGrantCount} unreferenced OAuth grant(s) from local storage`);

--- a/test/client.test.mjs
+++ b/test/client.test.mjs
@@ -8,6 +8,7 @@ async function loadClient({
   reactDomApi = { createPortal() {} },
   jsxRuntime = { jsx() {}, jsxs() {} },
   windowExtras = {},
+  sourceTransform = (source) => source,
 } = {}) {
   const source = await readFile(new URL('../lib/client.js', import.meta.url), 'utf8');
   let plugin;
@@ -33,7 +34,7 @@ async function loadClient({
       },
     },
   };
-  Function('window', 'document', source)(window, document);
+  Function('window', 'document', sourceTransform(source))(window, document);
   return plugin;
 }
 
@@ -213,6 +214,10 @@ test('市场标题展示安装版本，并通过 Provider 适配层一键更新'
 	assert.match(source, /provider\.start\(capabilities, PLUGIN_PACKAGE_NAME/);
 	assert.match(source, /provider\.operation\(capabilities, operationId\)/);
 	assert.match(source, /provider\.rollback\(capabilities, updateOperation\.operationId\)/);
+	assert.match(source, /completedUpdateIntegrityFailure\(operation, expectedUpdateVersion\)/);
+	assert.match(source, /provider\.rollback\(capabilities, operationId\)/);
+	assert.match(source, /DOWNGRADE_DETECTED/);
+	assert.match(source, /RESOLVED_VERSION_MISMATCH/);
 	assert.match(source, /provider\.restart\(capabilities\)/);
   assert.match(source, /一键更新到 v/);
   assert.match(source, /正在更新/);
@@ -227,6 +232,41 @@ test('市场标题展示安装版本，并通过 Provider 适配层一键更新'
   assert.match(source, /\^\(\\u63d2\\u4ef6\\u5e02\\u573a\|Plugin Market\|Plugin Marketplace\)\$/);
   assert.match(source, /window\.open\(NPM_PACKAGE_URL, "_blank", "noopener,noreferrer"\)/);
   assert.doesNotMatch(source, /registry\.npmjs\.org/, '客户端不应跨域请求版本源');
+});
+
+test('客户端独立拒绝 Provider 降级、错误目标和无效成功结果', async () => {
+  const plugin = await loadClient({
+    sourceTransform(source) {
+      return source.replace(
+        '\t\texports.apply = apply;',
+        '\t\texports.__testCompletedUpdateIntegrityFailure = completedUpdateIntegrityFailure;\n\t\texports.apply = apply;',
+      );
+    },
+  });
+  const verify = plugin.__testCompletedUpdateIntegrityFailure;
+  assert.equal(typeof verify, 'function');
+  assert.equal(verify({ state: 'running' }, '0.2.25'), null);
+  assert.equal(verify({
+    state: 'succeeded', beforeVersion: '0.2.24', installedVersion: '0.2.25',
+  }, '0.2.25'), null);
+  assert.deepEqual(verify({
+    state: 'succeeded', beforeVersion: '0.2.24', installedVersion: '0.2.23',
+  }, '0.2.25'), {
+    code: 'DOWNGRADE_DETECTED',
+    message: '更新服务将插件从 v0.2.24 降级到 v0.2.23',
+    retryable: false,
+  });
+  assert.deepEqual(verify({
+    state: 'succeeded', beforeVersion: '0.2.24', installedVersion: '0.2.26',
+  }, '0.2.25'), {
+    code: 'RESOLVED_VERSION_MISMATCH',
+    message: '预期安装 v0.2.25，更新服务实际安装了 v0.2.26',
+    retryable: true,
+  });
+  assert.equal(verify({
+    state: 'succeeded', beforeVersion: '1.0.0-beta.2', installedVersion: '1.0.0-beta.1',
+  }, '1.0.0-beta.3').code, 'DOWNGRADE_DETECTED');
+  assert.equal(verify({ state: 'succeeded', beforeVersion: '0.2.24' }, '0.2.25').code, 'INVALID_UPDATE_RESULT');
 });
 
 test('能力探测通过后渲染一键更新，并使用 Provider 广告的同源端点', async () => {

--- a/test/plugin-flow.test.mjs
+++ b/test/plugin-flow.test.mjs
@@ -354,6 +354,146 @@ test('grantSharing=issuer：不同卡片并发连接也只发起一次授权', {
   }
 });
 
+test('升级启动时把历史同 issuer 多 Grant 归并为最新共享授权', async () => {
+  const shared = { tables: new Map([['connections', makeTable()], ['grants', makeTable()], ['catalog', makeTable()]]) };
+  const auth = { mode: 'oauth2-pkce', issuer: 'https://oauth.example.com', scope: 'mcp:tools', clientName: 'upgrade-shared', grantSharing: 'issuer' };
+  const connectors = [
+    { id: 'upgrade-company', name: '历史企业', auth, servers: [{ serverKey: 'company', url: 'https://mcp.example.com/company', serverName: 'upgrade-company', transport: 'streamable-http', headers: {} }] },
+    { id: 'upgrade-risk', name: '历史风险', auth, servers: [{ serverKey: 'risk', url: 'https://mcp.example.com/risk', serverName: 'upgrade-risk', transport: 'streamable-http', headers: {} }] },
+  ];
+  const resources = connectors.flatMap((connector) => connector.servers.map((server) => server.url));
+  const now = Date.now();
+  const oldKey = 'grant:default:historical-old';
+  const newKey = 'grant:default:historical-new';
+  await shared.tables.get('grants').put(oldKey, {
+    key: oldKey, issuer: auth.issuer, clientId: 'old-client', scope: auth.scope, account: 'default',
+    accessToken: 'old-access', accessTokenExpiresAt: now + 3_600_000, refreshToken: 'old-refresh',
+    authorizedResources: resources, connectorIds: ['upgrade-company'], updatedAt: now - 10_000,
+  });
+  await shared.tables.get('grants').put(newKey, {
+    key: newKey, issuer: auth.issuer, clientId: 'new-client', scope: auth.scope, account: 'default',
+    accessToken: 'new-access', accessTokenExpiresAt: now + 3_600_000, refreshToken: 'new-refresh',
+    authorizedResources: resources, connectorIds: ['upgrade-risk'], updatedAt: now,
+  });
+  for (const [connector, grantKey] of [[connectors[0], oldKey], [connectors[1], newKey]]) {
+    const server = connector.servers[0];
+    await shared.tables.get('connections').put(`${connector.id}-${server.serverKey}`, {
+      key: `${connector.id}-${server.serverKey}`, connectorId: connector.id, kind: 'oauth', name: connector.name,
+      serverKey: server.serverKey, transport: server.transport, url: server.url, serverName: server.serverName,
+      headers: {}, auth: { mode: 'oauth', grantKey }, enabled: true, createdAt: now, updatedAt: now,
+    });
+  }
+
+  const { ctx, tools, tables, logs } = makePluginContext({ shared });
+  const { apply } = await import('../lib/index.js');
+  await apply(ctx, baseConfig({ connectors }));
+
+  const status = await tools.defs.get('mcp_connector_status').execute({});
+  assert.deepEqual([...new Set(status.detail.items.map((item) => item.grant.grantKey))], [newKey]);
+  assert.equal([...tables.get('grants').entries()].length, 1);
+  assert.deepEqual((await tables.get('grants').get(newKey)).connectorIds.sort(), ['upgrade-company', 'upgrade-risk']);
+  assert.ok(logs.some((line) => line.includes('historical OAuth grant')));
+});
+
+test('历史最新 Grant 已失效时先验证并选择仍可刷新的共享授权', { timeout: 10000 }, async () => {
+  const oauth = await createMockQccServer({ tokenResources: ['company', 'risk'] });
+  const shared = { tables: new Map([['connections', makeTable()], ['grants', makeTable()], ['catalog', makeTable()]]) };
+  const auth = { mode: 'oauth2-pkce', issuer: oauth.base, scope: 'mcp:tools', clientName: 'upgrade-validated', grantSharing: 'issuer' };
+  const connectors = [
+    { id: 'validated-company', name: '历史企业', auth, servers: [{ serverKey: 'company', url: `${oauth.base}/mcp/company/stream`, serverName: 'validated-company', transport: 'streamable-http', headers: {} }] },
+    { id: 'validated-risk', name: '历史风险', auth, servers: [{ serverKey: 'risk', url: `${oauth.base}/mcp/risk/stream`, serverName: 'validated-risk', transport: 'streamable-http', headers: {} }] },
+  ];
+  const resources = connectors.map((connector) => connector.servers[0].url);
+  const now = Date.now();
+  const validKey = 'grant:default:older-but-valid';
+  const invalidKey = 'grant:default:newer-but-invalid';
+  oauth.state.clients.set('valid-client', { clientSecret: undefined, tokenEndpointAuthMethod: 'none' });
+  oauth.state.clients.set('invalid-client', { clientSecret: undefined, tokenEndpointAuthMethod: 'none' });
+  oauth.state.refreshTokens.set('valid-refresh', { accessToken: 'expired', clientId: 'valid-client', expiresIn: 3600 });
+  await shared.tables.get('grants').put(validKey, {
+    key: validKey, issuer: oauth.base, clientId: 'valid-client', tokenEndpointAuthMethod: 'none',
+    scope: auth.scope, account: 'default', accessToken: 'expired-valid', accessTokenExpiresAt: now - 1_000,
+    refreshToken: 'valid-refresh', authorizedResources: resources, connectorIds: ['validated-company'], updatedAt: now - 10_000,
+  });
+  await shared.tables.get('grants').put(invalidKey, {
+    key: invalidKey, issuer: oauth.base, clientId: 'invalid-client', tokenEndpointAuthMethod: 'none',
+    scope: auth.scope, account: 'default', accessToken: 'expired-invalid', accessTokenExpiresAt: now - 1_000,
+    refreshToken: 'invalid-refresh', authorizedResources: resources, connectorIds: ['validated-risk'], updatedAt: now,
+  });
+  for (const [connector, grantKey] of [[connectors[0], validKey], [connectors[1], invalidKey]]) {
+    const server = connector.servers[0];
+    await shared.tables.get('connections').put(`${connector.id}-${server.serverKey}`, {
+      key: `${connector.id}-${server.serverKey}`, connectorId: connector.id, kind: 'oauth', name: connector.name,
+      serverKey: server.serverKey, transport: server.transport, url: server.url, serverName: server.serverName,
+      headers: {}, auth: { mode: 'oauth', grantKey }, enabled: true, createdAt: now, updatedAt: now,
+    });
+  }
+
+  const { ctx, tools, tables } = makePluginContext({ shared });
+  const { apply } = await import('../lib/index.js');
+  try {
+    await apply(ctx, baseConfig({ connectors }));
+    const status = await tools.defs.get('mcp_connector_status').execute({});
+    assert.deepEqual([...new Set(status.detail.items.map((item) => item.grant.grantKey))], [validKey]);
+    assert.equal([...tables.get('grants').entries()].length, 1);
+    assert.equal(oauth.state.refreshAttempts, 2, '应先拒绝新的失效 Grant，再刷新较旧的有效 Grant');
+    assert.equal(oauth.state.refreshCount, 1);
+  } finally {
+    await oauth.close();
+  }
+});
+
+test('并发进程轮换 refresh token 后重读持久化 Grant，避免误判重新授权', { timeout: 10000 }, async () => {
+  const oauth = await createMockQccServer({ tokenResources: ['company'] });
+  const baseGrantTable = makeTable();
+  let storageReads = 0;
+  const grantKey = 'grant:default:rotated-elsewhere';
+  const oldRefreshToken = 'refresh-token-used-by-other-process';
+  const newRefreshToken = 'refresh-token-persisted-by-other-process';
+  const now = Date.now();
+  const connector = {
+    id: 'refresh-rotation', name: '跨进程轮换',
+    auth: { mode: 'oauth2-pkce', issuer: oauth.base, scope: 'mcp:tools', clientName: 'rotation-test' },
+    servers: [{ serverKey: 'company', url: `${oauth.base}/mcp/company/stream`, serverName: 'refresh-rotation-company', transport: 'streamable-http', headers: {} }],
+  };
+  oauth.state.clients.set('stored-client', { clientSecret: undefined, tokenEndpointAuthMethod: 'none' });
+  oauth.state.refreshTokens.set(newRefreshToken, { accessToken: 'expired', clientId: 'stored-client', expiresIn: 3600 });
+  const oldGrant = {
+    key: grantKey, issuer: oauth.base, clientId: 'stored-client', tokenEndpointAuthMethod: 'none',
+    scope: 'mcp:tools', account: 'default', accessToken: 'expired-access', accessTokenExpiresAt: now - 1_000,
+    refreshToken: oldRefreshToken, authorizedResources: [connector.servers[0].url], connectorIds: [connector.id], updatedAt: now - 10_000,
+  };
+  const rotatedGrant = { ...oldGrant, refreshToken: newRefreshToken, updatedAt: now };
+  await baseGrantTable.put(grantKey, oldGrant);
+  const grants = {
+    ...baseGrantTable,
+    async get(key) {
+      storageReads += 1;
+      if (storageReads === 1) await baseGrantTable.put(grantKey, rotatedGrant);
+      return baseGrantTable.get(key);
+    },
+  };
+  const shared = { tables: new Map([['connections', makeTable()], ['grants', grants], ['catalog', makeTable()]]) };
+  await shared.tables.get('connections').put('refresh-rotation-company', {
+    key: 'refresh-rotation-company', connectorId: connector.id, kind: 'oauth', name: connector.name,
+    serverKey: 'company', transport: 'streamable-http', url: connector.servers[0].url,
+    serverName: 'refresh-rotation-company', headers: {}, auth: { mode: 'oauth', grantKey },
+    enabled: true, createdAt: now, updatedAt: now,
+  });
+  const { ctx, tools, loader, logs } = makePluginContext({ shared });
+  const { apply } = await import('../lib/index.js');
+  try {
+    await apply(ctx, baseConfig({ connectors: [connector] }));
+    const status = await tools.defs.get('mcp_connector_status').execute({});
+    assert.equal(status.detail.items[0].grant.needsReauth, false);
+    assert.ok(loader.entries.has('mcp-refresh-rotation-company'));
+    assert.equal(oauth.state.refreshCount, 1);
+    assert.ok(logs.some((line) => line.includes('concurrent rotation')));
+  } finally {
+    await oauth.close();
+  }
+});
+
 test('grantSharing=issuer 不跨 MCP 资源域复用 Bearer Token', { timeout: 30000 }, async () => {
   const firstOAuth = await createMockQccServer({ tokenResources: ['company'] });
   const secondOAuth = await createMockQccServer({ tokenResources: ['risk'] });


### PR DESCRIPTION
## 修复内容

- 升级启动时识别历史版本遗留的同 issuer 多份 OAuth Grant，先验证可刷新性，再安全归并为一组共享授权。
- 多个 DSH 进程并发轮换 Refresh Token 时，收到 invalid_grant 后重读本机持久化 Grant；发现较新 Token 即自动采用并重试，避免误报“需重新授权”。
- MCP连接器独立核验 Update Provider 返回的更新前、预期与实际版本；检测降级、目标偏差或无效成功结果时阻止重启，并在存在恢复点时自动回滚。
- 补充用户指南、更新协议和 Changelog。

## 根因

升级没有删除企查查凭据。历史版本为四张企查查卡片分别保存了独立 Grant；访问令牌过期后，插件重启会同时刷新多份轮换式 Refresh Token。并发进程可能已经持久化新 Token，而当前进程仍持有旧值，旧逻辑会直接把 invalid_grant 认定为永久失效。

同时，旧 Market 只判断“更新后版本是否变化”，没有拒绝 pnpm 因 minimumReleaseAge 或镜像滞后而解析出的更旧版本。

## 验证

- `npm run check`
- 129 项自动测试全部通过
- lint 通过
- npm 发布包白名单及敏感内容扫描通过
- 新增历史 Grant 归并、失效候选回退、跨进程 Token 轮换恢复与 Provider 版本完整性回归测试
