### PR TITLE
release: prepare v0.2.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [0.2.26] - 2026-08-27
+
 ### Fixed
 
 - 升级启动时自动发现并归并历史版本为同 issuer 卡片保存的多份 OAuth Grant；归并前先验证过期 Grant 是否仍可刷新，避免用较新但已失效的凭据覆盖可恢复授权。
@@ -424,7 +426,8 @@
 - 外部 URL 与导入 Header 执行安全校验。
 - iframe 消息校验同源和消息来源。
 
-[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.25...HEAD
+[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.26...HEAD
+[0.2.26]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.25...v0.2.26
 [0.2.25]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.24...v0.2.25
 [0.2.24]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.23...v0.2.24
 [0.2.23]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.22...v0.2.23

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mcp-connector",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "description": "General-purpose MCP connector, connection manager, plugin extension, and integration marketplace for DeepSeek Harness, initiated and maintained by Qichacha/QCC.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 发布内容

- 发布 MCP Connector v0.2.26。
- 收录 PR #19 的 OAuth 授权恢复修复：历史同 issuer Grant 安全归并、跨进程 Refresh Token 轮换恢复，避免升级后误报“需重新授权”。
- 收录 Update Provider 结果完整性校验：检测降级、目标版本偏差或无效成功结果时阻止重启，并在可用时自动回滚。

## 验证

- `npm run check`
- 129/129 自动测试通过
- lint 通过
- npm 发布包白名单和敏感内容扫描通过
- 发布差异仅包含 `package.json` 版本号与 `CHANGELOG.md` 归档
