### PR TITLE
release: prepare v0.2.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [0.2.27] - 2026-08-28
+
 ### Fixed
 
 - OAuth Refresh Token 轮换不再依赖 DSH JSON storage 的进程内缓存；新增每 Grant 独立原子日志和跨进程锁，Desktop 与 `dsh web` 同时运行时只轮换一次 Token，等待方直接采用最新凭据。
@@ -435,7 +437,8 @@
 - 外部 URL 与导入 Header 执行安全校验。
 - iframe 消息校验同源和消息来源。
 
-[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.26...HEAD
+[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.27...HEAD
+[0.2.27]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.26...v0.2.27
 [0.2.26]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.25...v0.2.26
 [0.2.25]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.24...v0.2.25
 [0.2.24]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.23...v0.2.24

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mcp-connector",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "General-purpose MCP connector, connection manager, plugin extension, and integration marketplace for DeepSeek Harness, initiated and maintained by Qichacha/QCC.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 发布内容

- 发布跨进程 OAuth Grant journal 与刷新锁修复
- 修复 DSH Desktop 没有插件市场分区时的更新入口降级
- 将包版本更新为 `0.2.27`
- 封口 `CHANGELOG.md` 的 v0.2.27 条目

## 发布前验证

- `npm run check`
- 134 项测试全部通过
- npm 发布包白名单与敏感信息审计通过
