### PR TITLE
release: v0.2.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ## [Unreleased]
 
+## [0.2.28] - 2026-08-29
+
+### Documentation
+
+- 重写 npm 和中英文 README 首屏产品介绍，前置 MCP Server 连接、OAuth 2.0 PKCE、stdio/HTTP、Registry 与工具/Prompt 发现等高意图能力。
+- 增加 npm 下载、GitHub Star/Fork/Release 徽标、真实演示、能力对比、中文教程入口与独立贡献指南。
+- 扩充 `model-context-protocol`、`mcp-registry`、`mcp-manager`、`streamable-http` 等高意图检索词。
+
+### Verification
+
+- 新增中英文 README 与 `package.json` 版本一致性门禁和 4 项回归测试；138 项自动测试、lint 与 npm 发布包白名单/敏感内容扫描通过。
+
 ## [0.2.27] - 2026-08-28
 
 ### Fixed
@@ -437,7 +449,8 @@
 - 外部 URL 与导入 Header 执行安全校验。
 - iframe 消息校验同源和消息来源。
 
-[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.27...HEAD
+[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.28...HEAD
+[0.2.28]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.27...v0.2.28
 [0.2.27]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.26...v0.2.27
 [0.2.26]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.25...v0.2.26
 [0.2.25]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.24...v0.2.25

--- a/README.en.md
+++ b/README.en.md
@@ -147,7 +147,7 @@ npm run dev:ui
 
 Every Registry merge regenerates `catalog-stats.json`; an hourly workflow in this repository synchronizes the Chinese and English product copy plus a local stats snapshot. The static npm README updates with package releases, while the live badges above read the Registry directly and therefore stay current without another npm release.
 
-The current public version is [`dsh-mcp-connector@0.2.27`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.27](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.27).
+The current public version is [`dsh-mcp-connector@0.2.28`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.28](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.28).
 
 See [CHANGELOG.md](CHANGELOG.md) for version history and [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md) for the Desktop release checklist.
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ npm run dev:ui
 
 公共 Registry 每次合并后会生成 `catalog-stats.json`；本仓库的定时工作流每小时同步中英文介绍和统计快照。npm 页面中的静态正文随版本发布更新，上方动态统计徽标则直接读取 Registry，可在不发布新 npm 版本时保持实时数量一致。
 
-当前公开版本为 [`dsh-mcp-connector@0.2.27`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.27](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.27)。
+当前公开版本为 [`dsh-mcp-connector@0.2.28`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.28](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.28)。
 
 版本能力与变更记录见 [CHANGELOG.md](CHANGELOG.md)。
 Desktop 发版回归见 [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mcp-connector",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "description": "Connect and manage MCP servers in DeepSeek Harness — a universal MCP connector and marketplace with OAuth 2.0 PKCE, API keys, stdio/HTTP, mcpServers JSON import, tools, and prompts. Maintained by Qichacha/QCC.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 概要
- 发布第一批 discoverability 与 README 优化
- 同步 package.json、中文 README、英文 README 为 0.2.28
- 记录元数据、徽标、演示、教程、贡献入口与版本一致性门禁

## 验证
- npm run check
- 138/138 tests passed
- npm pack allowlist and sensitive-content audit passed
- npm 0.2.28 confirmed unoccupied