### PR TITLE
release: v0.2.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [0.2.29] - 2026-08-30
+
 ### Fixed
 
 - 更新服务返回 `RELEASE_TOO_FRESH` 时明确提示“发布安全等待期”，不再误写为镜像同步；主动跳过等待的操作也改为“立即更新（跳过等待）”。
@@ -454,7 +456,8 @@
 - 外部 URL 与导入 Header 执行安全校验。
 - iframe 消息校验同源和消息来源。
 
-[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.28...HEAD
+[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.29...HEAD
+[0.2.29]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.28...v0.2.29
 [0.2.28]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.27...v0.2.28
 [0.2.27]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.26...v0.2.27
 [0.2.26]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.25...v0.2.26

--- a/README.en.md
+++ b/README.en.md
@@ -147,7 +147,7 @@ npm run dev:ui
 
 Every Registry merge regenerates `catalog-stats.json`; an hourly workflow in this repository synchronizes the Chinese and English product copy plus a local stats snapshot. The static npm README updates with package releases, while the live badges above read the Registry directly and therefore stay current without another npm release.
 
-The current public version is [`dsh-mcp-connector@0.2.28`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.28](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.28).
+The current public version is [`dsh-mcp-connector@0.2.29`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.29](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.29).
 
 See [CHANGELOG.md](CHANGELOG.md) for version history and [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md) for the Desktop release checklist.
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ npm run dev:ui
 
 公共 Registry 每次合并后会生成 `catalog-stats.json`；本仓库的定时工作流每小时同步中英文介绍和统计快照。npm 页面中的静态正文随版本发布更新，上方动态统计徽标则直接读取 Registry，可在不发布新 npm 版本时保持实时数量一致。
 
-当前公开版本为 [`dsh-mcp-connector@0.2.28`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.28](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.28)。
+当前公开版本为 [`dsh-mcp-connector@0.2.29`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.29](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.29)。
 
 版本能力与变更记录见 [CHANGELOG.md](CHANGELOG.md)。
 Desktop 发版回归见 [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mcp-connector",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "description": "Connect and manage MCP servers in DeepSeek Harness — a universal MCP connector and marketplace with OAuth 2.0 PKCE, API keys, stdio/HTTP, mcpServers JSON import, tools, and prompts. Maintained by Qichacha/QCC.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 发布内容

- 将版本升级至 0.2.29
- 发布更清晰的插件升级状态文案，区分安全等待期与镜像同步状态
- 无 Update Provider 时提供可复制的精确 DSH CLI 升级命令
- 同步中英文 README 和 CHANGELOG 版本信息

## 验证

- npm run check
- 146 tests passed
- lint、README 版本门禁、商店截图及 npm pack 校验全部通过

合并后将以 main 的合并提交创建 v0.2.29 Tag，由 release workflow 使用 npm Trusted Publishing 发布并创建 GitHub Release。