### PR TITLE
chore: release v0.2.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ## [Unreleased]
 
+## [0.2.30] - 2026-08-30
+
+### Added
+
+- 新增营销元数据事实源与线上/离线漂移检查，统一 npm 描述与关键词、GitHub About/Topics、中英文首屏 CTA 和外部分发文案。
+- 新增贡献模板、good first issue 入口、自然搜索/转化基线与发布前监控检查。
+
+### Changed
+
+- 更新中英文产品介绍、npm 检索词与 GitHub Topics，突出 MCP Server 连接、Registry、OAuth 2.0 PKCE 与 stdio/HTTP 能力。
+- 重新录制无真实凭据的市场截图与演示 GIF：实际两列卡片布局，企查查卡片不再展示“需重新授权”。
+- 已安装但尚无连接时不再强制弹出转化引导；首次连接成功或存在历史连接后才展示，且每页面生命周期仅一次。
+
+### Verification
+
+- 152 项自动测试、lint、npm 发布包白名单/敏感内容扫描、商店素材哈希与尺寸校验通过。
+
 ## [0.2.29] - 2026-08-30
 
 ### Fixed
@@ -456,7 +473,8 @@
 - 外部 URL 与导入 Header 执行安全校验。
 - iframe 消息校验同源和消息来源。
 
-[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.29...HEAD
+[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.30...HEAD
+[0.2.30]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.29...v0.2.30
 [0.2.29]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.28...v0.2.29
 [0.2.28]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.27...v0.2.28
 [0.2.27]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.26...v0.2.27

--- a/README.en.md
+++ b/README.en.md
@@ -150,7 +150,7 @@ npm run dev:ui
 
 Every Registry merge regenerates `catalog-stats.json`; an hourly workflow in this repository synchronizes the Chinese and English product copy plus a local stats snapshot. The static npm README updates with package releases, while the live badges above read the Registry directly and therefore stay current without another npm release.
 
-The current public version is [`dsh-mcp-connector@0.2.29`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.29](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.29).
+The current public version is [`dsh-mcp-connector@0.2.30`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.30](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.30).
 
 See [CHANGELOG.md](CHANGELOG.md) for version history and [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md) for the Desktop release checklist.
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ npm run dev:ui
 
 公共 Registry 每次合并后会生成 `catalog-stats.json`；本仓库的定时工作流每小时同步中英文介绍和统计快照。npm 页面中的静态正文随版本发布更新，上方动态统计徽标则直接读取 Registry，可在不发布新 npm 版本时保持实时数量一致。
 
-当前公开版本为 [`dsh-mcp-connector@0.2.29`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.29](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.29)。
+当前公开版本为 [`dsh-mcp-connector@0.2.30`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.30](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.30)。
 
 版本能力与变更记录见 [CHANGELOG.md](CHANGELOG.md)。
 Desktop 发版回归见 [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md)。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mcp-connector",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "description": "Connect and manage MCP servers in DeepSeek Harness — a universal MCP connector and marketplace with OAuth 2.0 PKCE, API keys, stdio/HTTP, mcpServers JSON import, tools, and prompts. Maintained by Qichacha/QCC.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## Summary

- release the discoverability and conversion improvements merged in #31
- publish corrected two-column storefront screenshots and credential-free QCC card state
- bump the public package and bilingual documentation to v0.2.30

## Verification

- npm run check
- 152 tests passed
- storefront hashes, dimensions, two-column viewport, and credential-free state verified
- 60 publish files passed allowlist and sensitive-content scanning

PR #30 remains draft and is not part of this release pending Windows + DSH 0.1.2 Alpha.1 validation.