### PR TITLE
fix: show restart when update is already installed

### DIFF
--- a/docs/PLUGIN-UPDATE.md
+++ b/docs/PLUGIN-UPDATE.md
@@ -25,6 +25,8 @@ DSH Market 适配器从 `GET /dsh-market/api/v1/capabilities` 开始，要求 `s
 5. 完整性校验通过后，按 Provider 返回的激活结论展示“刷新生效”或重启提示。Web 且 Provider 明确允许进程重启时才展示“立即重启”；Desktop 等由外壳管理生命周期的宿主只提示用户重启，不自行杀进程。
 6. Provider 保留恢复点时展示“回滚”。回滚仍由 Provider 执行，MCP连接器不直接修改 profile、lockfile 或 `node_modules`。
 
+Provider 读取的是 profile 中已经落盘的插件版本，标题版本来自当前运行中的插件进程。若 Provider 报告磁盘版本高于运行版本且已无后续更新，页面会显示“已安装，重启后生效”，并按 Provider 能力展示“立即重启”或宿主重启提示；此时不再重复给出同一版本的安装命令。
+
 失败结果使用稳定代码区分正在运行的 Agent、其他安装任务占用、发布安全等待、镜像同步、版本未变化、超时和权限拒绝，以及 `DOWNGRADE_DETECTED`、`RESOLVED_VERSION_MISMATCH`、`INVALID_UPDATE_RESULT` 三类完整性故障。`RELEASE_TOO_FRESH` 明确显示为约 24 小时的发布安全等待期，并提供“立即更新（跳过等待）”；真正的镜像同步故障保留独立提示，不再混用同一文案。
 
 当 DSH Desktop 或其他宿主没有兼容 Update Provider 时，标题区直接展示绑定 npm 精确版本的 CLI 命令，例如 `dsh plugin --profile web add --config.minimumReleaseAge=0 dsh-mcp-connector@<目标版本>`，并提供复制按钮与 npm 页面入口。运行时会把 `<目标版本>` 替换为 npm 已发布的确切版本；命令中的单次覆盖只用于用户主动跳过本次发布安全等待。Connector 仍不自行执行包管理器命令。

--- a/lib/client.js
+++ b/lib/client.js
@@ -460,6 +460,20 @@ window.__ModuleLoader__.load({
 			return 0;
 		}
 
+		/**
+		 * Provider 读取 profile 磁盘版本，versionStatus 来自当前运行中的插件进程。
+		 * 当磁盘版本更高且 Provider 已无后续更新时，说明安装已经完成、只差重启激活。
+		 */
+		function pendingActivationVersion(versionStatus, providerUpdateCheck) {
+			if (providerUpdateCheck?.updateAvailable !== false) return null;
+			const running = parseClientVersion(versionStatus?.installedVersion);
+			const installed = parseClientVersion(providerUpdateCheck?.installedVersion);
+			if (running === null || installed === null) return null;
+			return compareClientVersions(installed.normalized, running.normalized) > 0
+				? installed.normalized
+				: null;
+		}
+
 		/** Independently verify a provider's terminal success before asking the user to restart. */
 		function completedUpdateIntegrityFailure(operation, expectedVersion) {
 			if (operation?.state !== "succeeded") return null;
@@ -809,7 +823,11 @@ window.__ModuleLoader__.load({
 				});
 			};
 			const renderUpdateControls = () => {
-				if (!versionStatus?.updateAvailable && updateOperation === null && updateError === null) return null;
+				const activationPendingVersion = updateProviderState === "ready"
+					? pendingActivationVersion(versionStatus, providerUpdateCheck)
+					: null;
+				if (!versionStatus?.updateAvailable && activationPendingVersion === null
+					&& updateOperation === null && updateError === null) return null;
 				if (updateRunning) {
 					return /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
 						className: "mcpConnectorUpdateControls",
@@ -941,6 +959,33 @@ window.__ModuleLoader__.load({
 						title: `由 ${updateProviderSelection?.provider?.label ?? "更新服务"} 安全更新到 v${providerUpdateCheck.latestVersion}`,
 						onClick: () => startUpdate(false),
 						children: `一键更新到 v${providerUpdateCheck.latestVersion}`
+					});
+				}
+				if (activationPendingVersion !== null) {
+					const canRestart = updateProviderSelection?.capabilities?.restart?.supported === true;
+					return /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
+						className: "mcpConnectorUpdateControls",
+						children: [
+							/* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
+								className: "mcpConnectorUpdateStatus",
+								children: `v${activationPendingVersion} 已安装，重启后生效`
+							}),
+							canRestart
+								? /* @__PURE__ */ (0, react_jsx_runtime.jsx)("button", {
+									type: "button",
+									className: "mcpConnectorUpdateButton",
+									disabled: restarting,
+									onClick: restartHost,
+									children: restarting ? "正在重启…" : "立即重启"
+								})
+								: /* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
+									className: "mcpConnectorUpdateStatus",
+									title: `重启由 ${updateProviderSelection?.capabilities?.restart?.managedBy ?? "宿主"} 管理`,
+									children: updateProviderSelection?.capabilities?.runtime === "desktop"
+										? "请重启 DSH Desktop"
+										: "请重启 DSH"
+								})
+						]
 					});
 				}
 				const command = manualUpgradeCommand(versionStatus?.latestVersion);

--- a/test/client.test.mjs
+++ b/test/client.test.mjs
@@ -333,6 +333,98 @@ test('更新失败文案区分发布安全等待和镜像同步', async () => {
   assert.equal(label({ code: 'UNKNOWN', message: '镜像返回的安装包尚不可用' }), '镜像返回的安装包尚不可用');
 });
 
+test('磁盘版本高于运行版本时识别为等待重启，不重复提示安装', async () => {
+  const plugin = await loadClient({
+    sourceTransform(source) {
+      return source.replace(
+        '\t\texports.apply = apply;',
+        '\t\texports.__testPendingActivationVersion = pendingActivationVersion;\n\t\texports.apply = apply;',
+      );
+    },
+  });
+  const pending = plugin.__testPendingActivationVersion;
+  assert.equal(pending(
+    { installedVersion: '0.2.30', latestVersion: '0.2.31', updateAvailable: true },
+    { installedVersion: '0.2.31', latestVersion: '0.2.31', updateAvailable: false },
+  ), '0.2.31');
+  assert.equal(pending(
+    { installedVersion: '0.2.31' },
+    { installedVersion: '0.2.31', latestVersion: '0.2.31', updateAvailable: false },
+  ), null);
+  assert.equal(pending(
+    { installedVersion: '0.2.30' },
+    { installedVersion: '0.2.31', latestVersion: '0.2.32', updateAvailable: true },
+  ), null, '仍有更高版本时应继续展示一键更新');
+  assert.equal(pending(
+    { installedVersion: 'invalid' },
+    { installedVersion: '0.2.31', updateAvailable: false },
+  ), null);
+
+  const source = await readFile(new URL('../lib/client.js', import.meta.url), 'utf8');
+  assert.match(source, /v\$\{activationPendingVersion\} 已安装，重启后生效/);
+  assert.match(source, /pendingActivationVersion\(versionStatus, providerUpdateCheck\)/);
+});
+
+test('已安装的新版本在旧进程中渲染重启提示而非升级命令', async () => {
+  const state = [
+    { installedVersion: '0.2.30', latestVersion: '0.2.31', updateAvailable: true },
+    'ready',
+    {
+      provider: { id: 'market-v1', label: 'DSH 插件市场' },
+      capabilities: {
+        runtime: 'web',
+        restart: { supported: false, managedBy: 'operator' },
+      },
+    },
+    { installedVersion: '0.2.31', latestVersion: '0.2.31', updateAvailable: false },
+    null,
+    null,
+    null,
+    false,
+    false,
+    false,
+    false,
+  ];
+  let stateCursor = 0;
+  const jsxRuntime = {
+    jsx(type, props) { return { type, props }; },
+    jsxs(type, props) { return { type, props }; },
+  };
+  const plugin = await loadClient({
+    jsxRuntime,
+    windowExtras: { location: { origin: 'http://127.0.0.1:3080' } },
+    reactApi: {
+      useState(initial) {
+        const index = stateCursor++;
+        return [index in state ? state[index] : initial, () => {}];
+      },
+      useRef(initial) { return { current: initial }; },
+      useEffect() {},
+    },
+  });
+  const { ctx, registrations } = clientContext();
+  plugin.apply(ctx);
+  const component = registrations.get('shell.overlay').component;
+  const tree = component({
+    wide: true,
+    useStore: (select) => select({ open: true, detailOpen: false }),
+    actions: { close() {}, detailOpened() {}, detailClosed() {} },
+    startPromptSession() {},
+  });
+  const descendants = [];
+  const visit = (node) => {
+    if (node == null || node === false || typeof node !== 'object') return;
+    descendants.push(node);
+    const children = node.props?.children;
+    for (const child of Array.isArray(children) ? children : [children]) visit(child);
+  };
+  visit(tree);
+  assert.ok(descendants.some((node) => node.props?.children === 'v0.2.31 已安装，重启后生效'));
+  assert.ok(descendants.some((node) => node.props?.children === '请重启 DSH'));
+  assert.equal(descendants.some((node) => node.type === 'code'), false);
+  assert.equal(descendants.some((node) => node.props?.children === '复制升级命令'), false);
+});
+
 test('能力探测通过后渲染一键更新，并使用 Provider 广告的同源端点', async () => {
   const requests = [];
   const effects = [];


### PR DESCRIPTION
## Summary
- detect when the update provider reports a newer version already installed on disk
- show a restart-required state instead of repeating the same CLI install command
- document the activation-pending state and add unit/component regressions

## Verification
- npm run check (156/156 tests passed)
- git diff --check