### PR TITLE
docs: promote the over-one-hundred connector catalog

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,6 @@
 # MCP Connector and MCP Server Marketplace for DeepSeek Harness
 
-> A universal MCP connector and marketplace for connecting, authorizing, discovering, and managing MCP servers, initiated and maintained by the Qichacha (QCC) team
+> DeepSeek Harness MCP Connector and MCP Server marketplace with over one hundred MCP connectors, continuously updated; discover, authorize, and manage connections in one place with OAuth 2.0 PKCE, API keys, stdio/HTTP, mcpServers JSON import, and tool and prompt discovery; maintained by Qichacha/QCC
 
 Manage MCP connections from different providers in one place inside DeepSeek Harness Desktop/Web. Use OAuth 2.0 PKCE, API keys, stdio/HTTP, `mcpServers` JSON import, tool and prompt discovery, and an independently updated Registry of curated connectors.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MCP连接器：DeepSeek Harness MCP Server 连接与管理市场
 
-> 连接、授权、发现和管理 MCP Server 的通用 MCP Connector 与 Marketplace，由企查查（Qichacha/QCC）团队发起并维护
+> DeepSeek Harness 的 MCP连接器与 MCP Server 市场，收录超百个 MCP连接器并持续更新；统一发现、授权和连接管理，支持 OAuth 2.0 PKCE、API Key、stdio/HTTP、mcpServers JSON 导入，以及工具与 Prompt 发现；由企查查/QCC 团队维护
 
 在 DeepSeek Harness Desktop/Web 中一站式管理不同厂商的 MCP 连接：支持 OAuth 2.0 PKCE、API Key、stdio/HTTP、`mcpServers` JSON 导入、工具与 Prompt 发现，并通过独立 Registry 持续更新精选连接器目录。
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,6 +1,6 @@
 # DSH MCP Connector Distribution Ledger
 
-Last updated: 2026-08-31 (Asia/Shanghai)
+Last updated: 2026-09-01 (Asia/Shanghai)
 
 This document is the source of truth for external distribution of
 [`duhu2000/dsh-mcp-connector`](https://github.com/duhu2000/dsh-mcp-connector).
@@ -114,8 +114,8 @@ the destination schema without changing the product identity.
 - Install: `dsh plugin --profile web add dsh-mcp-connector`
 - Remove: `dsh plugin --profile web remove dsh-mcp-connector`
 - Supported target: DeepSeek Harness Desktop/web profile; Node.js 20+
-- English description: `Connect and manage MCP servers in DeepSeek Harness — a universal MCP connector and marketplace with OAuth 2.0 PKCE, API keys, stdio/HTTP, mcpServers JSON import, tools, and prompts. Maintained by Qichacha/QCC.`
-- Chinese description: `DeepSeek Harness 通用 MCP 连接器、连接管理与扩展市场：连接 MCP Server，发现工具与 Prompt，扩展 AI 技能；支持 OAuth 2.0 PKCE、API Key、stdio/HTTP 和 `mcpServers` JSON 导入。由企查查（Qichacha/QCC）团队发起维护。`
+- English description: `DeepSeek Harness MCP Connector and MCP Server marketplace with over one hundred MCP connectors, continuously updated. Discover, authorize, and manage connections in one place; supports OAuth 2.0 PKCE, API keys, stdio/HTTP, mcpServers JSON import, and tool and prompt discovery. Maintained by Qichacha/QCC.`
+- Chinese description: `DeepSeek Harness 的 MCP连接器与 MCP Server 市场，收录超百个 MCP连接器并持续更新；统一发现、授权和连接管理，支持 OAuth 2.0 PKCE、API Key、stdio/HTTP、mcpServers JSON 导入，以及工具与 Prompt 发现；由企查查/QCC 团队维护。`
 - Screenshots and evidence: [`docs/screenshots/README.md`](screenshots/README.md)
 - Release history: [`CHANGELOG.md`](../CHANGELOG.md)
 

--- a/duhu2000__dsh-mcp-connector.yml
+++ b/duhu2000__dsh-mcp-connector.yml
@@ -2,5 +2,5 @@ url: https://github.com/duhu2000/dsh-mcp-connector
 name: duhu2000/dsh-mcp-connector
 category: tools
 description:
-  en: 'General-purpose MCP Connector Marketplace for DeepSeek Harness with OAuth 2.0 PKCE, API key and URL configuration, JSON import, dynamic tool discovery, prompt-to-session workflows, and connection management.'
-  zh: 'DeepSeek Harness 通用 MCP 连接器市场，支持 OAuth 2.0 PKCE、API Key/URL 配置、JSON 导入、动态工具发现、Prompt 发起新会话和连接管理。'
+  en: 'DeepSeek Harness MCP Connector and MCP Server marketplace with over one hundred MCP connectors, continuously updated. Discover, authorize, and manage connections in one place; supports OAuth 2.0 PKCE, API keys, stdio/HTTP, mcpServers JSON import, and tool and prompt discovery. Maintained by Qichacha/QCC.'
+  zh: 'DeepSeek Harness 的 MCP连接器与 MCP Server 市场，收录超百个 MCP连接器并持续更新；统一发现、授权和连接管理，支持 OAuth 2.0 PKCE、API Key、stdio/HTTP、mcpServers JSON 导入，以及工具与 Prompt 发现；由企查查/QCC 团队维护。'

--- a/marketing/metadata.json
+++ b/marketing/metadata.json
@@ -3,7 +3,7 @@
   "repository": "duhu2000/dsh-mcp-connector",
   "packageName": "dsh-mcp-connector",
   "npm": {
-    "description": "Connect and manage MCP servers in DeepSeek Harness — a universal MCP connector and marketplace with OAuth 2.0 PKCE, API keys, stdio/HTTP, mcpServers JSON import, tools, and prompts. Maintained by Qichacha/QCC.",
+    "description": "DeepSeek Harness MCP Connector and MCP Server marketplace with over one hundred MCP connectors, continuously updated. Discover, authorize, and manage connections in one place; supports OAuth 2.0 PKCE, API keys, stdio/HTTP, mcpServers JSON import, and tool and prompt discovery. Maintained by Qichacha/QCC.",
     "requiredKeywords": [
       "deepseek-harness",
       "deepseek",
@@ -28,7 +28,7 @@
     ]
   },
   "github": {
-    "description": "DeepSeek Harness 通用 MCP连接器、连接管理与扩展市场：连接 MCP Server，发现工具与 Prompt，扩展 AI 技能；支持 OAuth/PKCE、API Key、JSON 导入。由企查查（Qichacha/QCC）团队发起维护。General-purpose MCP connector, connection manager, plugin, extension and integration marketplace.",
+    "description": "DeepSeek Harness MCP Connector and MCP Server marketplace with over one hundred MCP connectors. Discover, authorize, and manage connections; supports OAuth 2.0 PKCE, API keys, stdio/HTTP, mcpServers JSON import, and tool and prompt discovery. Maintained by Qichacha/QCC.",
     "topics": [
       "deepseek-harness",
       "deepseek",
@@ -53,14 +53,14 @@
     ]
   },
   "readme": {
-    "heroZh": "> 连接、授权、发现和管理 MCP Server 的通用 MCP Connector 与 Marketplace，由企查查（Qichacha/QCC）团队发起并维护",
-    "heroEn": "> A universal MCP connector and marketplace for connecting, authorizing, discovering, and managing MCP servers, initiated and maintained by the Qichacha (QCC) team",
+    "heroZh": "> DeepSeek Harness 的 MCP连接器与 MCP Server 市场，收录超百个 MCP连接器并持续更新；统一发现、授权和连接管理，支持 OAuth 2.0 PKCE、API Key、stdio/HTTP、mcpServers JSON 导入，以及工具与 Prompt 发现；由企查查/QCC 团队维护",
+    "heroEn": "> DeepSeek Harness MCP Connector and MCP Server marketplace with over one hundred MCP connectors, continuously updated; discover, authorize, and manage connections in one place with OAuth 2.0 PKCE, API keys, stdio/HTTP, mcpServers JSON import, and tool and prompt discovery; maintained by Qichacha/QCC",
     "ctaZh": "如果它帮你更快地接入 MCP Server，欢迎 [GitHub 点个 Star](https://github.com/duhu2000/dsh-mcp-connector/stargazers)、[提交新的连接器](https://github.com/duhu2000/dsh-mcp-connector-registry/blob/main/docs/ONBOARDING.md)或[参与贡献](CONTRIBUTING.md)。",
     "ctaEn": "If the plugin helps you connect an MCP server faster, consider [starring the repository](https://github.com/duhu2000/dsh-mcp-connector/stargazers), [submitting a connector](https://github.com/duhu2000/dsh-mcp-connector-registry/blob/main/docs/ONBOARDING.md), or [contributing a fix](CONTRIBUTING.md)."
   },
   "externalListing": {
-    "en": "General-purpose MCP Connector Marketplace for DeepSeek Harness with OAuth 2.0 PKCE, API key and URL configuration, JSON import, dynamic tool discovery, prompt-to-session workflows, and connection management.",
-    "zh": "DeepSeek Harness 通用 MCP 连接器市场，支持 OAuth 2.0 PKCE、API Key/URL 配置、JSON 导入、动态工具发现、Prompt 发起新会话和连接管理。"
+    "en": "DeepSeek Harness MCP Connector and MCP Server marketplace with over one hundred MCP connectors, continuously updated. Discover, authorize, and manage connections in one place; supports OAuth 2.0 PKCE, API keys, stdio/HTTP, mcpServers JSON import, and tool and prompt discovery. Maintained by Qichacha/QCC.",
+    "zh": "DeepSeek Harness 的 MCP连接器与 MCP Server 市场，收录超百个 MCP连接器并持续更新；统一发现、授权和连接管理，支持 OAuth 2.0 PKCE、API Key、stdio/HTTP、mcpServers JSON 导入，以及工具与 Prompt 发现；由企查查/QCC 团队维护。"
   },
   "links": {
     "repository": "https://github.com/duhu2000/dsh-mcp-connector",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-mcp-connector",
   "version": "0.2.32",
-  "description": "Connect and manage MCP servers in DeepSeek Harness — a universal MCP connector and marketplace with OAuth 2.0 PKCE, API keys, stdio/HTTP, mcpServers JSON import, tools, and prompts. Maintained by Qichacha/QCC.",
+  "description": "DeepSeek Harness MCP Connector and MCP Server marketplace with over one hundred MCP connectors, continuously updated. Discover, authorize, and manage connections in one place; supports OAuth 2.0 PKCE, API keys, stdio/HTTP, mcpServers JSON import, and tool and prompt discovery. Maintained by Qichacha/QCC.",
   "type": "module",
   "main": "lib/index.js",
   "exports": {

--- a/scripts/check-marketing-metadata.mjs
+++ b/scripts/check-marketing-metadata.mjs
@@ -75,6 +75,29 @@ export async function checkMarketingMetadata({ live = false, liveGithub = live, 
   contains(readmeEn, metadata.readme.ctaEn, 'English README CTA differs from marketing metadata');
   contains(externalListing, `en: ${yamlSingleQuoted(metadata.externalListing.en)}`, 'external English listing differs from marketing metadata');
   contains(externalListing, `zh: ${yamlSingleQuoted(metadata.externalListing.zh)}`, 'external Chinese listing differs from marketing metadata');
+
+  const externalEnglish = [
+    ['npm description', metadata.npm.description],
+    ['GitHub description', metadata.github.description],
+    ['English README hero', metadata.readme.heroEn],
+    ['external English listing', metadata.externalListing.en],
+  ];
+  for (const [label, copy] of externalEnglish) {
+    contains(copy, 'DeepSeek Harness', `${label} must retain the external platform identity`);
+    contains(copy.toLowerCase(), 'over one hundred mcp connectors', `${label} must use the durable over-one-hundred connector claim`);
+    contains(copy.toLowerCase(), 'discover', `${label} must describe connector discovery`);
+    contains(copy.toLowerCase(), 'authorize', `${label} must describe authorization`);
+    contains(copy.toLowerCase(), 'manage', `${label} must describe connection management`);
+  }
+  for (const [label, copy] of [
+    ['Chinese README hero', metadata.readme.heroZh],
+    ['external Chinese listing', metadata.externalListing.zh],
+  ]) {
+    contains(copy, 'DeepSeek Harness', `${label} must retain the external platform identity`);
+    contains(copy, '超百个 MCP连接器', `${label} must use the durable over-one-hundred connector claim`);
+    contains(copy, '统一发现、授权和连接管理', `${label} must describe discovery, authorization, and management`);
+  }
+
   contains(contributing, metadata.links.firstIssues, 'contributor guide is missing the good first issue path');
   for (const key of ['stars', 'contributing', 'connectorOnboarding']) {
     contains(ui, metadata.links[key], `installed-state CTA is missing ${key} link`);


### PR DESCRIPTION
## Summary

- update npm, GitHub, README, distribution, and external-listing source copy to the durable “over one hundred MCP connectors” / “超百个 MCP连接器” claim
- retain the DeepSeek Harness identity in every external channel
- keep exact 101 only in the dated, generated Registry statistics block
- add metadata checks for the platform identity, catalog scale, discovery, authorization, and connection-management claims

## Count evidence

The generated 2026-09-01 statistics record 97 public Registry descriptors plus 4 unique bundled Qichacha cards after deduplication, for 101 visible marketplace cards. A refreshed DSH page has been manually accepted at 101.

## Verification

- `npm run check`
- 156 tests passed
- package allowlist and credential/path scan passed for 60 published files

This PR does not publish a new npm version. The npm storefront description should be updated with the next verified release rather than creating a copy-only release.