### PR TITLE
fix: remove version-specific client module dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 - 已保存但尚未观察到检查结果的连接，以及 Host 暂时无法确认的 stdio 注册状态，现在明确显示“状态未知”；不再以“已配置”暗示连接可用。
 - JSON 脱敏导出会移除 Token、API Key、OAuth Grant、本地路径、Header/env 值与 stdio 参数；占位符未重填时整批拒绝导入。连接配置、导入、启停或断开失败时不保留无效快照。
 
+### Fixed
+
+- 客户端入口移除对 Host 版本特有的 Store、Runtime 和 UI Primitives 模块依赖；弹窗状态改用内置标准 Slot Store contract，避免 Windows Desktop 模块表差异导致插件树加载失败并进入 Safe Mode。
+
 ### Documentation
 
 - 新增 project/global 作用域文档，说明继承、Host 强制执行、凭据单份存储、同名 Server 冲突、Workspace 删除和失败回滚边界。
@@ -29,7 +33,7 @@
 
 ### Verification
 
-- 189 项自动测试、lint、版本/营销元数据/商店截图门禁和 npm 发布包白名单/敏感内容扫描全部通过。
+- 190 项自动测试、lint、版本/营销元数据/商店截图门禁和 npm 发布包白名单/敏感内容扫描全部通过。
 
 ## [0.2.32] - 2026-08-31
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -7,20 +7,6 @@ window.__ModuleLoader__.load({
 		let react_jsx_runtime = require("react/jsx-runtime");
 		let react = require("react");
 		let react_dom = require("react-dom");
-		let _deepseek_ai_dsh_client_ui_primitives = require("@deepseek-ai/dsh-client-ui-primitives");
-		let defineStore;
-		try {
-			({ defineStore } = require("@deepseek-ai/dsh-client-store"));
-		} catch (storeError) {
-			try {
-				({ defineStore } = require("@deepseek-ai/dsh-client-runtime/client"));
-			} catch (runtimeError) {
-				throw new AggregateError(
-					[storeError, runtimeError],
-					"mcp-connector: DSH client store is unavailable"
-				);
-			}
-		}
 
 		/** 客户端所需服务：槽位、工作区、会话及对话输入机。 */
 		const inject = [
@@ -65,6 +51,8 @@ window.__ModuleLoader__.load({
 
 .mcpConnectorLauncher {
 	flex: none;
+	display: flex;
+	align-items: center;
 	box-sizing: border-box;
 	width: calc(100% + 4px);
 	height: 42px;
@@ -72,8 +60,20 @@ window.__ModuleLoader__.load({
 	padding: 0 10px 0 8px;
 	justify-content: flex-start;
 	overflow: hidden;
+	border: 0;
 	border-radius: 12px;
+	background: transparent;
+	color: inherit;
+	font: inherit;
 	white-space: nowrap;
+	cursor: pointer;
+}
+
+.mcpConnectorLauncher:hover,
+.mcpConnectorLauncher:focus-visible {
+	background: rgba(127, 127, 127, 0.12);
+	outline: 2px solid currentColor;
+	outline-offset: 1px;
 }
 
 .mcpConnectorLauncher[data-wide="false"] {
@@ -542,9 +542,13 @@ window.__ModuleLoader__.load({
 			}, 0);
 		}
 
-		/** 创建弹框 store（使用 DSH defineStore，与社区插件市场一致）。 */
+		/**
+		 * 创建符合 DSH Slot Store contract 的本地状态句柄。
+		 * 只依赖 getSnapshot/subscribe/actions，避免不同 Host 版本的 Store
+		 * 包名或客户端模块到达顺序让整个 Desktop 进入 Safe Mode。
+		 */
 		function createMarketViewStore() {
-			return defineStore({
+			const spec = {
 				init: () => ({ open: false, detailOpen: false }),
 				actions: {
 					open: (draft) => { draft.open = true; },
@@ -552,7 +556,32 @@ window.__ModuleLoader__.load({
 					detailOpened: (draft) => { draft.detailOpen = true; },
 					detailClosed: (draft) => { draft.detailOpen = false; }
 				}
-			});
+			};
+			return {
+				spec,
+				create() {
+					let state = spec.init();
+					const listeners = new Set();
+					const actions = {};
+					for (const [name, mutate] of Object.entries(spec.actions)) {
+						actions[name] = (...params) => {
+							const draft = { ...state };
+							mutate(draft, ...params);
+							state = draft;
+							for (const listener of listeners) listener();
+						};
+					}
+					return {
+						actions,
+						getSnapshot: () => state,
+						subscribe(listener) {
+							listeners.add(listener);
+							return () => { listeners.delete(listener); };
+						},
+						clearPersisted() {}
+					};
+				}
+			};
 		}
 
 		/**
@@ -1181,8 +1210,8 @@ window.__ModuleLoader__.load({
 					for (const mount of ownedMounts) mount.remove();
 				};
 			}, []);
-			const launcher = /* @__PURE__ */ (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.Button, {
-				variant: "ghost",
+			const launcher = /* @__PURE__ */ (0, react_jsx_runtime.jsx)("button", {
+				type: "button",
 				className: "mcpConnectorLauncher",
 				"data-wide": wide,
 				"aria-label": "MCP连接器",

--- a/test/client.test.mjs
+++ b/test/client.test.mjs
@@ -8,7 +8,6 @@ async function loadClient({
   reactDomApi = { createPortal() {} },
   jsxRuntime = { jsx() {}, jsxs() {} },
   windowExtras = {},
-  storeModule = 'runtime',
   sourceTransform = (source) => source,
 } = {}) {
   const source = await readFile(new URL('../lib/client.js', import.meta.url), 'utf8');
@@ -26,13 +25,6 @@ async function loadClient({
           if (id === 'react/jsx-runtime') return jsxRuntime;
           if (id === 'react') return reactApi;
           if (id === 'react-dom') return reactDomApi;
-          if (id === '@deepseek-ai/dsh-client-store' && storeModule === 'store') {
-            return { defineStore: (definition) => definition };
-          }
-          if (id === '@deepseek-ai/dsh-client-runtime/client' && storeModule === 'runtime') {
-            return { defineStore: (definition) => definition };
-          }
-          if (id === '@deepseek-ai/dsh-client-ui-primitives') return { Button() {} };
           throw new Error(`unexpected client import: ${id}`);
         });
       },
@@ -94,10 +86,32 @@ test('客户端声明新会话所需服务', async () => {
   assert.deepEqual(plugin.inject, ['slots', 'sessions', 'workspaces', 'conversation']);
 });
 
-test('客户端 Store 兼容 Alpha.1 新模块与 0.1.1 旧模块', async () => {
-  await assert.doesNotReject(() => loadClient({ storeModule: 'store' }));
-  await assert.doesNotReject(() => loadClient({ storeModule: 'runtime' }));
-  await assert.rejects(() => loadClient({ storeModule: 'missing' }), /DSH client store is unavailable/);
+test('客户端入口不依赖 Host 版本特有的 Store、Runtime 或 UI Primitives 模块', async () => {
+  await assert.doesNotReject(() => loadClient());
+  const source = await readFile(new URL('../lib/client.js', import.meta.url), 'utf8');
+  assert.doesNotMatch(source, /require\("@deepseek-ai\/dsh-client-(?:store|runtime|ui-primitives)/);
+});
+
+test('内置弹框 Store 实现标准快照、订阅与动作 contract', async () => {
+  const plugin = await loadClient();
+  const { ctx, registrations } = clientContext();
+  plugin.apply(ctx);
+  const handle = registrations.get('shell.overlay').options.store;
+  const instance = handle.create();
+  let changes = 0;
+  const unsubscribe = instance.subscribe(() => { changes += 1; });
+
+  assert.deepEqual(instance.getSnapshot(), { open: false, detailOpen: false });
+  instance.actions.open();
+  instance.actions.detailOpened();
+  assert.deepEqual(instance.getSnapshot(), { open: true, detailOpen: true });
+  instance.actions.close();
+  assert.deepEqual(instance.getSnapshot(), { open: false, detailOpen: false });
+  assert.equal(changes, 3);
+  unsubscribe();
+  instance.actions.open();
+  assert.equal(changes, 3);
+  assert.doesNotThrow(() => instance.clearPersisted());
 });
 
 test('侧栏入口使用公开插槽托管，并具备工作区上方 Portal 与底部降级', async () => {

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -32,16 +32,14 @@ test('bundle patch uses the same jsDelivr primary catalog source', () => {
   assert.doesNotMatch(patch, /catalogUrl:\s*['"]https:\/\/raw\.githubusercontent\.com/);
 });
 
-test('client bundle uses the host-version store baseline without impossible dynamic externals', () => {
+test('client bundle is self-contained across Host store/runtime module layouts', () => {
   const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
   const clientSource = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8');
-  const storeSpecifier = '@deepseek-ai/dsh-client-store';
-  const runtimeSpecifier = '@deepseek-ai/dsh-client-runtime/client';
 
-  assert.match(clientSource, new RegExp(`require\\(\"${storeSpecifier}\"\\)`));
-  assert.match(clientSource, new RegExp(`require\\(\"${runtimeSpecifier}\"\\)`));
-  assert.match(clientSource, /catch \(storeError\)/);
+  assert.doesNotMatch(clientSource, /require\("@deepseek-ai\/dsh-client-(?:store|runtime|ui-primitives)/);
   assert.equal(packageJson.dsh.client.external, undefined);
   assert.ok(!packageJson.dsh.client.inject.includes('@deepseek-ai/dsh-client-runtime'));
+  assert.equal(packageJson.peerDependencies['@deepseek-ai/dsh-client-store'], undefined);
+  assert.equal(packageJson.peerDependencies['@deepseek-ai/dsh-client-ui-primitives'], undefined);
   assert.equal(packageJson.peerDependencies['@deepseek-ai/dsh-client-runtime'], undefined);
 });


### PR DESCRIPTION
## Root cause and boundary

The client entry used a runtime fallback across two Host-specific Store package layouts. On the reporter's Windows Desktop module table, neither dependency was guaranteed to have arrived before the connector factory materialized, so the fallback require itself could fail and place Desktop in Safe Mode.

## Fix

- remove client imports of DSH Store, Runtime, and UI Primitives packages
- implement the documented Slot Store handle contract locally with getSnapshot, subscribe, actions, and clearPersisted
- use a styled native accessible button for the sidebar launcher
- add regression gates that reject version-specific client imports and exercise the local Store lifecycle

Adding peerDependencies alone would not guarantee browser module-table arrival and could make installation stricter without fixing boot, so this PR removes the unstable dependency boundary.

## Verification

- 190 automated tests
- lint, README/version, marketing metadata, storefront screenshots
- npm package whitelist and sensitive-content scan: 67 files
- official DSH 0.1.2-alpha.1 exact-source main UI boot: connector entry visible, market opens, connector client has 0 errors
- test package SHA-256: 132d7a6162eec2f1313605f18dea7d15a3cbc7de40bb1945ab45b969398a144b

Closes #49