### PR TITLE
chore: release v0.2.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [0.2.34] - 2026-09-04
+
 ### Added
 
 - 用户自建连接可对 RFC1918 IPv4 / RFC4193 IPv6 ULA 字面量显式授权明文 HTTP；默认仍拒绝，公网 HTTP、域名、链路本地与元数据地址不受该开关影响。
@@ -536,7 +538,10 @@
 - 外部 URL 与导入 Header 执行安全校验。
 - iframe 消息校验同源和消息来源。
 
-[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.31...HEAD
+[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.34...HEAD
+[0.2.34]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.33...v0.2.34
+[0.2.33]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.32...v0.2.33
+[0.2.32]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.31...v0.2.32
 [0.2.31]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.30...v0.2.31
 [0.2.30]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.29...v0.2.30
 [0.2.29]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.28...v0.2.29

--- a/README.en.md
+++ b/README.en.md
@@ -171,7 +171,7 @@ npm run dev:ui
 
 Every Registry merge regenerates `catalog-stats.json`; an hourly workflow in this repository synchronizes the Chinese and English product copy plus a local stats snapshot. The static npm README updates with package releases, while the live badges above read the Registry directly and therefore stay current without another npm release.
 
-The current public version is [`dsh-mcp-connector@0.2.33`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.33](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.33).
+The current public version is [`dsh-mcp-connector@0.2.34`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.34](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.34).
 
 See [CHANGELOG.md](CHANGELOG.md) for version history and [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md) for the Desktop release checklist.
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ npm run dev:ui
 
 公共 Registry 每次合并后会生成 `catalog-stats.json`；本仓库的定时工作流每小时同步中英文介绍和统计快照。npm 页面中的静态正文随版本发布更新，上方动态统计徽标则直接读取 Registry，可在不发布新 npm 版本时保持实时数量一致。
 
-当前公开版本为 [`dsh-mcp-connector@0.2.33`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.33](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.33)。
+当前公开版本为 [`dsh-mcp-connector@0.2.34`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.34](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.34)。
 
 版本能力与变更记录见 [CHANGELOG.md](CHANGELOG.md)。
 Desktop 发版回归见 [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md)。

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,6 +1,6 @@
 # DSH MCP Connector Distribution Ledger
 
-Last updated: 2026-09-02 (Asia/Shanghai)
+Last updated: 2026-09-04 (Asia/Shanghai)
 
 This document is the source of truth for external distribution of
 [`duhu2000/dsh-mcp-connector`](https://github.com/duhu2000/dsh-mcp-connector).
@@ -15,7 +15,7 @@ the same upstream data source.
 | Product | MCP Connector / MCP连接器 |
 | Repository | [`duhu2000/dsh-mcp-connector`](https://github.com/duhu2000/dsh-mcp-connector) |
 | npm package | [`dsh-mcp-connector`](https://www.npmjs.com/package/dsh-mcp-connector) |
-| Current release | `0.2.33` |
+| Current release | `0.2.34` |
 | License | MIT |
 | GitHub discovery topic | `dsh-plugin` |
 | Plugin type | DSH client plugin, MCP connection manager, and connector marketplace |
@@ -109,7 +109,7 @@ the destination schema without changing the product identity.
 
 - Repository: `https://github.com/duhu2000/dsh-mcp-connector`
 - npm: `https://www.npmjs.com/package/dsh-mcp-connector`
-- Release: `0.2.33`
+- Release: `0.2.34`
 - License: MIT
 - Category preference: `Integrations & Connectors`; otherwise
   `Plugins & Runtime`, `Integration`, or `Plugin Markets & Managers`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mcp-connector",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "description": "DeepSeek Harness MCP Connector and MCP Server marketplace with over one hundred MCP connectors, continuously updated. Discover, authorize, and manage connections in one place; supports OAuth 2.0 PKCE, API keys, stdio/HTTP, mcpServers JSON import, and tool and prompt discovery. Maintained by Qichacha/QCC.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## Release
- publish the explicit per-connection LAN HTTP consent added by PR #55
- publish staged OAuth diagnostics for provider-side DCR HTTP 403 failures
- publish callback-listener cleanup for failures before browser authorization
- repair missing v0.2.32 and v0.2.33 changelog comparison links

## Verification
- npm run check: 194/194 tests passed
- verify-pack: 67 files passed

Release tag and npm publication will be created only after this PR is merged and CI is green.