### PR TITLE
chore: release v0.2.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@
 
 ## [Unreleased]
 
+## [0.2.35] - 2026-09-05
+
 ### Fixed
 
 - 市场详情内完成免密连接、凭据配置或 OAuth 重新授权后，现在会原地重新读取连接状态与工具清单，并同步启用 Prompt 和试用按钮；用户在刷新期间主动关闭或切换详情时不会被强制重新打开。
+
+### Verification
+
+- 195 项自动测试、lint、版本/营销元数据/商店截图门禁和 npm 发布包白名单/敏感内容扫描全部通过。
 
 ## [0.2.34] - 2026-09-04
 
@@ -542,7 +548,8 @@
 - 外部 URL 与导入 Header 执行安全校验。
 - iframe 消息校验同源和消息来源。
 
-[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.34...HEAD
+[Unreleased]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.35...HEAD
+[0.2.35]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.34...v0.2.35
 [0.2.34]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.33...v0.2.34
 [0.2.33]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.32...v0.2.33
 [0.2.32]: https://github.com/duhu2000/dsh-mcp-connector/compare/v0.2.31...v0.2.32

--- a/README.en.md
+++ b/README.en.md
@@ -171,7 +171,7 @@ npm run dev:ui
 
 Every Registry merge regenerates `catalog-stats.json`; an hourly workflow in this repository synchronizes the Chinese and English product copy plus a local stats snapshot. The static npm README updates with package releases, while the live badges above read the Registry directly and therefore stay current without another npm release.
 
-The current public version is [`dsh-mcp-connector@0.2.34`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.34](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.34).
+The current public version is [`dsh-mcp-connector@0.2.35`](https://www.npmjs.com/package/dsh-mcp-connector), with [GitHub Release v0.2.35](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.35).
 
 See [CHANGELOG.md](CHANGELOG.md) for version history and [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md) for the Desktop release checklist.
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ npm run dev:ui
 
 公共 Registry 每次合并后会生成 `catalog-stats.json`；本仓库的定时工作流每小时同步中英文介绍和统计快照。npm 页面中的静态正文随版本发布更新，上方动态统计徽标则直接读取 Registry，可在不发布新 npm 版本时保持实时数量一致。
 
-当前公开版本为 [`dsh-mcp-connector@0.2.34`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.34](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.34)。
+当前公开版本为 [`dsh-mcp-connector@0.2.35`](https://www.npmjs.com/package/dsh-mcp-connector)，对应 [GitHub Release v0.2.35](https://github.com/duhu2000/dsh-mcp-connector/releases/tag/v0.2.35)。
 
 版本能力与变更记录见 [CHANGELOG.md](CHANGELOG.md)。
 Desktop 发版回归见 [docs/DESKTOP-E2E.md](docs/DESKTOP-E2E.md)。

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,6 +1,6 @@
 # DSH MCP Connector Distribution Ledger
 
-Last updated: 2026-09-04 (Asia/Shanghai)
+Last updated: 2026-09-05 (Asia/Shanghai)
 
 This document is the source of truth for external distribution of
 [`duhu2000/dsh-mcp-connector`](https://github.com/duhu2000/dsh-mcp-connector).
@@ -15,7 +15,7 @@ the same upstream data source.
 | Product | MCP Connector / MCP连接器 |
 | Repository | [`duhu2000/dsh-mcp-connector`](https://github.com/duhu2000/dsh-mcp-connector) |
 | npm package | [`dsh-mcp-connector`](https://www.npmjs.com/package/dsh-mcp-connector) |
-| Current release | `0.2.34` |
+| Current release | `0.2.35` |
 | License | MIT |
 | GitHub discovery topic | `dsh-plugin` |
 | Plugin type | DSH client plugin, MCP connection manager, and connector marketplace |
@@ -109,7 +109,7 @@ the destination schema without changing the product identity.
 
 - Repository: `https://github.com/duhu2000/dsh-mcp-connector`
 - npm: `https://www.npmjs.com/package/dsh-mcp-connector`
-- Release: `0.2.34`
+- Release: `0.2.35`
 - License: MIT
 - Category preference: `Integrations & Connectors`; otherwise
   `Plugins & Runtime`, `Integration`, or `Plugin Markets & Managers`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mcp-connector",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "description": "DeepSeek Harness MCP Connector and MCP Server marketplace with over one hundred MCP connectors, continuously updated. Discover, authorize, and manage connections in one place; supports OAuth 2.0 PKCE, API keys, stdio/HTTP, mcpServers JSON import, and tool and prompt discovery. Maintained by Qichacha/QCC.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## User problem / 用户问题

发布连接器详情状态刷新修复。此前完成连接后，详情弹窗仍显示“未连接”，工具清单、Prompt 与试用按钮不会立即更新。

## Change / 改动

- 发布版本由 0.2.34 更新为 0.2.35。
- 将 PR #57 的通用连接后原地刷新修复纳入正式版本。
- 同步中英文 README、分发台账和 Changelog 版本引用。
- 保持 Unreleased 比较链接指向 v0.2.35 之后的变更。

## Verification / 验证

- [x] `npm run check`
- [x] 195/195 自动测试通过
- [x] lint、版本/营销元数据、商店截图门禁通过
- [x] npm 发布包白名单与敏感内容扫描通过
- [x] 版本引用统一为 0.2.35
- [x] 未包含 Token、API Key、Cookie、OAuth 凭据、私有 URL、本机路径或真实业务数据

## Release notes / 发布说明

合并后再创建 `v0.2.35` 标签，由 GitHub Actions 通过 npm Trusted Publishing 发布，并生成 GitHub Release；标签不得早于 release PR 合并。
